### PR TITLE
Add deduplicate flag in llm()

### DIFF
--- a/R/llm.R
+++ b/R/llm.R
@@ -13,6 +13,7 @@
 #' @param text_col The name of the text column if text is a data frame
 #' @param model the LLM model name (see `llm_model_list()`) in the format "provider" or "provider/model"
 #' @param params a named list to pass to `ellmer::params()`
+#' @param deduplicate boolean to determine whether identical prompt+text inputs should be discarded
 #'
 #' @return a list of results
 #'
@@ -27,7 +28,8 @@
 llm <- function(text, system_prompt,
                 text_col = "text",
                 model = llm_model(),
-                params = list()) {
+                params = list(),
+                deduplicate = TRUE) {
   ## error detection ----
   if (!llm_use()) {
     stop("Set llm_use(TRUE) to use LLM functions")
@@ -40,7 +42,11 @@ llm <- function(text, system_prompt,
   }
 
   # set up answer data frame to return ----
-  unique_text <- unique(text[[text_col]])
+  if (deduplicate) {
+    unique_text <- unique(text[[text_col]])
+  } else {
+    unique_text <- text[[text_col]]
+  }
   ncalls <- length(unique_text)
   responses <- replicate(ncalls, list(), simplify = FALSE)
 


### PR DESCRIPTION
This allows inputs containing identical text + prompt combinations to test the stability of output with certain parameters (thinking level, model type, temperature). Default set at TRUE so all default downstream behavior remains the same.