### PR TITLE
Fix/tei xref url fragment crash

### DIFF
--- a/R/grobid.R
+++ b/R/grobid.R
@@ -717,6 +717,17 @@ tei_authors <- function(xml) {
 #' @keywords internal
 tei_xrefs <- function(xml, text_table) {
   text <- text_id <- xref_id <- xref_type <- NULL
+  safe_html_text <- function(x) {
+    out <- tryCatch(
+      xml2::xml_text(xml2::read_html(x)),
+      error = function(e) NA_character_
+    )
+    if (length(out) == 0) {
+      return(NA_character_)
+    }
+    out[[1]]
+  }
+
   xrefs <- xml2::xml_find_all(xml, "//ref")
   if (length(xrefs) == 0) {
     return(data.frame(
@@ -747,14 +758,22 @@ tei_xrefs <- function(xml, text_table) {
     tidytext::unnest_sentences(output = "text", input = "p", to_lower = FALSE) |>
     dplyr::filter(grepl("<ref", text, fixed = TRUE)) |>
     dplyr::rowwise() |>
-    dplyr::filter(
-      (is.na(xref_id) & grepl(contents, xml2::read_html(text) |> xml2::xml_text(), fixed = TRUE)) |
-        grepl(paste0("#", xref_id), text, fixed = TRUE)
-    )
+    dplyr::filter({
+      id_match <- !is.na(xref_id) && grepl(paste0("#", xref_id), text, fixed = TRUE)
+      if (id_match) {
+        TRUE
+      } else if (is.na(xref_id)) {
+        text_plain <- safe_html_text(text)
+        !is.na(text_plain) && grepl(contents, text_plain, fixed = TRUE)
+      } else {
+        FALSE
+      }
+    })
 
   if (nrow(xref_data) > 0) {
     xref_data <- xref_data |>
-      dplyr::mutate(text = xml2::read_html(text) |> xml2::xml_text()) |>
+      dplyr::mutate(text = sapply(text, safe_html_text)) |>
+      dplyr::mutate(text = ifelse(is.na(text), p, text)) |>
       dplyr::ungroup() |>
       dplyr::arrange(xref_type, gsub("\\D", "", x = xref_id) |> as.integer())
   }

--- a/tests/testthat/test-grobid.R
+++ b/tests/testthat/test-grobid.R
@@ -179,6 +179,23 @@ test_that("both grobid xml and bibr", {
   expect_s3_class(obs, "scivrs_paperlist")
 })
 
+test_that("tei_xrefs handles URL refs with query strings", {
+  xml <- xml2::read_xml(
+    "<TEI><text><body><p>The gridded soil data are available at <ref type='url' target='https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=2358'>ORNL DAAC</ref> for download.</p></body></text></TEI>"
+  )
+
+  text_table <- data.frame(
+    text_id = 1,
+    text = "The gridded soil data are available at ORNL DAAC for download.",
+    stringsAsFactors = FALSE
+  )
+
+  expect_no_error(
+    xrefs <- metacheck:::tei_xrefs(xml, text_table)
+  )
+  expect_s3_class(xrefs, "data.frame")
+})
+
 # convert_grobid ----
 
 test_that("convert_grobid", {


### PR DESCRIPTION
I observed an error reading in an xml file (s41559-024-02483-9.xml, an ecology paper). 
I could not resolve it myself, so I asked github copilot to implement a change which was most robust, least likely to cause other bugs, and the fastest solution. I asked not to add copilot as a collaborator. Below is a description of the problem and fix by AI:

Summary
This PR fixes a crash during TEI XML conversion when cross-reference sentence fragments contain truncated URL ref tags (for example, a fragment ending at ...? inside a <ref ... target="..."> attribute).

Problem
Some XML files parsed successfully at document level, but failed later in tei_xrefs() during sentence-level xref matching.
The failure occurred when read_html() was called on a malformed sentence fragment created by sentence tokenization of tagged content.

Observed error:

Memory allocation failed [2] from read_xml.raw() via read_html()
Root Cause
tei_xrefs() parsed sentence fragments as HTML inside a rowwise filter.
For URL refs with query strings, sentence splitting could cut the fragment mid-tag, producing invalid HTML input for read_html().

Fix
Added safe HTML-to-text helper in tei_xrefs() that catches parser errors and returns NA instead of failing.
Reordered matching logic to short-circuit on xref_id match first (no HTML parse needed in that case).
Kept NA-target matching behavior, but made it robust by using safe parsing.
Added fallback behavior when text conversion fails, preventing pipeline crashes.
Test Coverage
Added regression test:

tei_xrefs handles URL refs with query strings
This test ensures URL refs with query parameters do not crash xref extraction.

Validation
Ran targeted tests:

devtools::test(filter = "grobid")
Result: pass (existing unrelated warning/skip remains unchanged)
Scope
This PR is intentionally minimal and only includes:
xref parsing robustness fix
one regression test for the reproduced failure mode
No module behavior outside TEI xref parsing was intentionally changed.