### PR TITLE
add check and warning for p-values of exactly 0

### DIFF
--- a/inst/modules/stat_p_exact.R
+++ b/inst/modules/stat_p_exact.R
@@ -1,10 +1,10 @@
 #' Exact P-Values
 #'
 #' @description
-#' List any p-values reported with insufficient precision (e.g., p < .05 or p = n.s.)
+#' List any p-values reported with insufficient precision (e.g., p < .05 or p = n.s.) or reported as exactly zero (e.g., p = .000).
 #'
 #' @details
-#' This module uses regular expressions to identify p-values. It will flag any values reported as p > ? or p < numbers greater than .001.
+#' This module uses regular expressions to identify p-values. It will flag any values reported as p > ? or p < numbers greater than .001. It will also flag p-values reported as exactly zero (e.g., p = .000, p = 0.00), which are mathematically impossible — p-values are never exactly zero and should instead be reported as p < .001.
 #'
 #' We try to exclude figure and table notes like "* p < .05", but may not succeed at excluding all false positives.
 #'
@@ -39,18 +39,25 @@ stat_p_exact <- function(paper) {
   stars <- grepl(star_pattern, p$expanded)
   p$imprecise <- p$imprecise & !stars
 
+  # Flag p-values reported as exactly zero (e.g., p = .000, p = 0.00)
+  p$zero <- p$p_comp == "=" & !is.na(p$p_value) & p$p_value == 0
+
   cols <- c("text", "expanded")
   report_table <- unique(p[p$imprecise, cols, drop = FALSE])
   colnames(report_table) <- c("P-Value", "Text")
 
+  zero_table <- unique(p[p$zero, cols, drop = FALSE])
+  colnames(zero_table) <- c("P-Value", "Text")
+
   # summary_table ----
-  summary_table <- p[p$imprecise, , drop = FALSE]
-  summary_table <- dplyr::count(summary_table, paper_id, name = "n_imprecise")
+  imprecise_summary <- dplyr::count(p[p$imprecise, , drop = FALSE], paper_id, name = "n_imprecise")
+  zero_summary <- dplyr::count(p[p$zero, , drop = FALSE], paper_id, name = "n_zero")
+  summary_table <- dplyr::full_join(imprecise_summary, zero_summary, by = "paper_id")
 
   # traffic light ----
   if (nrow(p) == 0) {
     tl <- "na"
-  } else if (nrow(report_table) == 0) {
+  } else if (nrow(report_table) == 0 && nrow(zero_table) == 0) {
     tl <- "green"
   } else {
     tl <- "red"
@@ -62,19 +69,32 @@ stat_p_exact <- function(paper) {
     summary_text <- report
   } else if (tl == "green") {
     report <- sprintf(
-      "We found no imprecise *p* values out of %d detected.",
+      "We found no imprecise *p* values or *p*-values of exactly zero out of %d detected.",
       nrow(p)
     )
     summary_text <- report
   } else {
+    summary_parts <- c()
+    if (nrow(report_table) > 0) {
+      summary_parts <- c(summary_parts, sprintf(
+        "%d imprecise *p* value%s",
+        nrow(report_table),
+        plural(nrow(report_table))
+      ))
+    }
+    if (nrow(zero_table) > 0) {
+      summary_parts <- c(summary_parts, sprintf(
+        "%d *p* value%s reported as exactly zero",
+        nrow(zero_table),
+        plural(nrow(zero_table))
+      ))
+    }
     summary_text <- sprintf(
-      "We found %d imprecise *p* value%s out of %d detected.",
-      nrow(report_table),
-      plural(nrow(report_table)),
-      nrow(p)
+      "We found %s out of %d detected *p* value%s.",
+      paste(summary_parts, collapse = " and "),
+      nrow(p),
+      plural(nrow(p))
     )
-
-    report_text <- "Reporting *p* values imprecisely (e.g., *p* < .05) reduces transparency, reproducibility, and re-use (e.g., in *p* value meta-analyses). Best practice is to report exact p-values with three decimal places (e.g., *p* = .032) unless *p* values are smaller than 0.001, in which case you can use *p* < .001."
 
     # Guidance text
     apa <- bibentry(
@@ -87,17 +107,39 @@ stat_p_exact <- function(paper) {
       publisher = "American Psychological Association"
     )
 
-    guidance <- c(
-      "The APA manual states: Report exact *p* values (e.g., *p* = .031) to two or three decimal places. However, report *p* values less than .001 as *p* < .001. However, 2 decimals is too imprecise for many use-cases (e.g., a *p* value meta-analysis), so report *p* values with three digits.",
-      format_ref(apa)
-    )
+    report <- c()
 
-    # Combine everything into report text
-    report <- c(
-      report_text,
-      scroll_table(report_table, colwidths = c(.1, .9)),
-      collapse_section(guidance)
-    )
+    if (nrow(report_table) > 0) {
+      report_text <- "Reporting *p* values imprecisely (e.g., *p* < .05) reduces transparency, reproducibility, and re-use (e.g., in *p* value meta-analyses). Best practice is to report exact p-values with three decimal places (e.g., *p* = .032) unless *p* values are smaller than 0.001, in which case you can use *p* < .001."
+
+      guidance <- c(
+        "The APA manual states: Report exact *p* values (e.g., *p* = .031) to two or three decimal places. However, report *p* values less than .001 as *p* < .001. However, 2 decimals is too imprecise for many use-cases (e.g., a *p* value meta-analysis), so report *p* values with three digits.",
+        format_ref(apa)
+      )
+
+      report <- c(
+        report,
+        report_text,
+        scroll_table(report_table, colwidths = c(.1, .9)),
+        collapse_section(guidance)
+      )
+    }
+
+    if (nrow(zero_table) > 0) {
+      zero_text <- "*P* values are never exactly zero. A *p* value of .000 is a rounding artifact — the actual value is simply smaller than the reported precision. Very small *p* values should be reported as *p* < .001 rather than *p* = .000."
+
+      zero_guidance <- c(
+        "The APA manual states: report *p* values less than .001 as *p* < .001.",
+        format_ref(apa)
+      )
+
+      report <- c(
+        report,
+        zero_text,
+        scroll_table(zero_table, colwidths = c(.1, .9)),
+        collapse_section(zero_guidance)
+      )
+    }
   }
 
   # ---- Return list ----

--- a/tests/testthat/test-module-stat.R
+++ b/tests/testthat/test-module-stat.R
@@ -25,6 +25,32 @@ test_that("stat_p_exact", {
   expect_equal(mod_output$traffic_light, "red")
   expect_equal(nrow(mod_output$table), 11)
 
+  # zero p-values
+  paper <- test_paper(c(
+    "Significant result (p = .000)",
+    "Significant result (p = 0.000)",
+    "Significant result (p = 0.00)"
+  ))
+
+  mod_output <- module_run(paper, module)
+  expect_equal(mod_output$traffic_light, "red")
+  expect_equal(nrow(mod_output$table), 3)
+  expect_true(all(mod_output$table$zero))
+  expect_false(any(mod_output$table$imprecise))
+  expect_equal(mod_output$summary_table$n_zero, 3)
+
+  # imprecise and zero together
+  paper <- test_paper(c(
+    "Imprecise p-value example (p < .05)",
+    "Zero p-value example (p = .000)"
+  ))
+
+  mod_output <- module_run(paper, module)
+  expect_equal(mod_output$traffic_light, "red")
+  expect_equal(nrow(mod_output$table), 2)
+  expect_equal(sum(mod_output$table$imprecise), 1)
+  expect_equal(sum(mod_output$table$zero), 1)
+
   # iteration
   paper <- psychsci
   mod_output <- module_run(paper, module)


### PR DESCRIPTION
Added updates to the function, and tests for the additions. My tests pass, manual checks of the report look good. I did identify a new category of false positives (p = 0. 0 0 - with spaces) but made an issue about this, as it should be fixed in the all_p_values module