### PR TITLE
Fix code_check crash and missing paper_id on paper lists

### DIFF
--- a/inst/modules/code_check.R
+++ b/inst/modules/code_check.R
@@ -43,7 +43,7 @@ code_check <- function(paper, file_limit = 20, local_path = NULL, local_only = F
   all_files$language <- code_lang(all_files$file_name)
 
   ## find relevant code files ----
-  relevant <- all_files$lang %in% c("R", "SAS", "SPSS", "Stata")
+  relevant <- all_files$language %in% c("R", "SAS", "SPSS", "Stata")
   code_files <- all_files[relevant, , drop = FALSE]
 
   summary_code <- sprintf(
@@ -115,7 +115,9 @@ code_check <- function(paper, file_limit = 20, local_path = NULL, local_only = F
         file_lines <- code_read(file_path)
       }
 
-      # try to parse R-type code
+      # try to parse R-type code; NA (not assessed) for other languages
+      the_file$parse_error <- NA
+      the_file$parse_error_msg <- NA_character_
       if (the_file$language == "R") {
         parse_check <- code_parse_r(text = file_lines)
         the_file$parse_error <- parse_check$error
@@ -314,16 +316,17 @@ code_check <- function(paper, file_limit = 20, local_path = NULL, local_only = F
     tl <- "yellow"
   }
 
-  # Aggregate by project
-  summary_table <- data.frame(
-    paper_id = paper$paper_id,
-    code_n = nrow(code_files),
-    code_checked = sum(code_files$checked, na.rm = TRUE),
-    code_abs_path = sum(code_files$code_abs_path, na.rm = TRUE),
-    code_missing_files = sum(code_files$loaded_files_missing, na.rm = TRUE),
-    code_min_comments = min(code_files$percentage_comment, na.rm = TRUE),
-    code_parse_errors = sum(code_files$parse_error, na.rm = TRUE)
-  )
+  # Aggregate by paper
+  summary_table <- code_files |>
+    dplyr::summarise(
+      code_n = dplyr::n(),
+      code_checked = sum(checked, na.rm = TRUE),
+      code_abs_path = sum(code_abs_path, na.rm = TRUE),
+      code_missing_files = sum(loaded_files_missing, na.rm = TRUE),
+      code_min_comments = min(percentage_comment, na.rm = TRUE),
+      code_parse_errors = sum(parse_error, na.rm = TRUE),
+      .by = paper_id
+    )
 
   # summary_text ----
   summary_text <- c(

--- a/inst/modules/repo_check.R
+++ b/inst/modules/repo_check.R
@@ -285,7 +285,16 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE) {
   }
   all_files$repo_name <- basename(all_files$repo_url)
 
-  repos <- dplyr::full_join(repos, all_files, by = "repo_url") |>
+  # attach paper_id so downstream modules (e.g., code_check) know which
+  # paper each file belongs to, even when a repo is shared across papers
+  all_files <- dplyr::left_join(
+    all_files,
+    repos[, c("paper_id", "repo_url")],
+    by = "repo_url",
+    relationship = "many-to-many"
+  )
+
+  repos <- dplyr::full_join(repos, all_files, by = c("paper_id", "repo_url"), relationship = "many-to-many") |>
     dplyr::summarise(
       files_n = sum(!is.na(file_name)),
       files_data = sum(file_type %in% "data"),

--- a/tests/testthat/test-module-code_check.R
+++ b/tests/testthat/test-module-code_check.R
@@ -270,6 +270,7 @@ test_that("parse errors", {
   mo <- module_run(paper, module, local_path = local_path)
 
   exp <- data.frame(
+    paper_id = rep(paper_id(paper), 8),
     repo_name = rep("parse-errors", 8),
     repo_url = rep(local_path, 8),
     file_name = c(


### PR DESCRIPTION
fixes a bug in code_check that occured for paperlist objects (i.e., when running on many papers at once). 

The function tried to build a results table using paper$paper_id — but paper_id is only stored that way for a single paper object. For a list of papers, you have to ask for it differently (paper_id(paper)), and the wrong version silently returned nothing. Mixing "nothing" with other normal-sized results is what triggered the row-count error. There was also a small typo (lang instead of language) that meant the file-language filter wasn't working as intended, and a separate paper-tracking column (paper_id) was missing entirely from an earlier step (repo_check()), so even after fixing the typo, there was no way to know which paper each code file actually belonged to.

The fix:

Added the missing paper_id column earlier in the pipeline (repo_check.R), so every code file is correctly tagged with the paper it came from.
Rewrote the results table in code_check.R to group and summarize results per paper instead of assuming there's only one.
Fixed the lang/language typo.
Made sure every file gets the same set of result columns (e.g., "did parsing fail?") even for file types where that check doesn't apply, so combining results from different file types doesn't break.


