### PR TITLE
fix(schema): sync bundled paper.json to bibr v10.5

### DIFF
--- a/inst/schema/paper.json
+++ b/inst/schema/paper.json
@@ -2,68 +2,298 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://scienceverse.org/schema/paper.json",
   "title": "Bibr Paper",
-  "description": "A research paper, as processed by bibr (v10.0)",
+  "description": "A research paper, as processed by bibr (v10.5)",
   "type": "object",
   "properties": {
     "paper_id": {
       "description": "A unique ID for each paper (user-supplied > file_name)",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "info": {
       "$ref": "#/$defs/info"
     },
     "author": {
       "type": "array",
-      "items": { "$ref": "#/$defs/author" },
+      "items": {
+        "$ref": "#/$defs/author"
+      },
       "uniqueItems": true
     },
     "text": {
       "type": "array",
-      "items": { "$ref": "#/$defs/text" },
+      "items": {
+        "$ref": "#/$defs/text"
+      },
       "uniqueItems": true
     },
     "section": {
       "type": "array",
-      "items": { "$ref": "#/$defs/section" },
+      "items": {
+        "$ref": "#/$defs/section"
+      },
       "uniqueItems": true
     },
     "url": {
       "description": "Hyperlinks found in the paper text",
       "type": "array",
-      "items": { "$ref": "#/$defs/url" },
+      "items": {
+        "$ref": "#/$defs/url"
+      },
       "uniqueItems": true
     },
     "bib": {
       "type": "array",
-      "items": { "$ref": "#/$defs/bib" },
+      "items": {
+        "$ref": "#/$defs/bib"
+      },
       "uniqueItems": true
     },
     "xref": {
+      "description": "In-text cross-references. NOT uniqueItems: two identical mentions in one sentence legitimately produce identical rows.",
       "type": "array",
-      "items": { "$ref": "#/$defs/xref" },
-      "uniqueItems": true
+      "items": {
+        "$ref": "#/$defs/xref"
+      }
     },
     "figure": {
       "type": "array",
-      "items": { "$ref": "#/$defs/figure" },
+      "items": {
+        "$ref": "#/$defs/figure"
+      },
       "uniqueItems": true
     },
     "table": {
       "type": "array",
-      "items": { "$ref": "#/$defs/table" },
+      "items": {
+        "$ref": "#/$defs/table"
+      },
       "uniqueItems": true
     },
     "eq": {
       "type": "array",
-      "items": { "$ref": "#/$defs/eq" }
+      "items": {
+        "$ref": "#/$defs/eq"
+      }
     },
     "bib_match": {
       "type": "array",
-      "items": { "$ref": "#/$defs/bib_match" },
+      "items": {
+        "$ref": "#/$defs/bib_match"
+      },
       "uniqueItems": true
+    },
+    "info_match": {
+      "description": "Enrichment matches for the paper's OWN bibliographic identity (self-DOI lookup); shaped like bib_match minus bib_id",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/info_match"
+      }
+    },
+    "funding": {
+      "description": "Structured funding parsed from the funding statement",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/funding"
+      }
+    },
+    "affiliations": {
+      "description": "Structured affiliations parsed from the author byline",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/affiliation"
+      }
+    },
+    "ocr_config": {
+      "description": "OCR/LLM backend configuration used for this extraction",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "ocr_backend": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ocr_model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "llm_provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "llm_model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "no_llm": {
+          "type": "boolean"
+        }
+      }
+    },
+    "enrichment": {
+      "description": "Reference-enrichment completeness; null/absent when enrichment never ran",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "complete",
+        "refs_enriched",
+        "refs_total"
+      ],
+      "properties": {
+        "complete": {
+          "type": "boolean"
+        },
+        "refs_enriched": {
+          "type": "integer"
+        },
+        "refs_total": {
+          "type": "integer"
+        }
+      }
+    },
+    "processing_warnings": {
+      "description": "Human-readable pipeline warnings; VALIDATION:<severity>:<code>: lines mirror the validation block",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "llm_usage": {
+      "description": "Per-paper LLM token usage keyed by model name; null when no LLM ran",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "integer"
+        }
+      }
+    },
+    "extraction": {
+      "description": "Extraction provenance; null when exported outside the pipeline",
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "bibr_version",
+        "ref_seg_strategy",
+        "ref_parse_strategy",
+        "ref_seg_fallback_used",
+        "crossref_enrich",
+        "consolidate"
+      ],
+      "properties": {
+        "bibr_version": {
+          "description": "bibr package version (e.g. 0.3.0), distinct from info.schema_version",
+          "type": "string"
+        },
+        "ref_seg_strategy": {
+          "type": "string"
+        },
+        "ref_parse_strategy": {
+          "type": "string"
+        },
+        "ref_seg_fallback_used": {
+          "type": "boolean"
+        },
+        "crossref_enrich": {
+          "type": "boolean"
+        },
+        "consolidate": {
+          "type": "string"
+        },
+        "timings": {
+          "description": "Per-stage wall-clock seconds",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "total_seconds": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
+    "validation": {
+      "description": "Output validation gate result; absent when the gate was skipped",
+      "type": "object",
+      "required": [
+        "errors",
+        "warnings",
+        "issues"
+      ],
+      "properties": {
+        "errors": {
+          "type": "integer"
+        },
+        "warnings": {
+          "type": "integer"
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "code",
+              "severity",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "error",
+                  "warning"
+                ]
+              },
+              "message": {
+                "type": "string"
+              },
+              "count": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "_regions": {
+      "description": "Opt-in per-region layout debug payload (bibr include_regions=True); not part of the stable consumer API",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
     }
   },
-
   "required": [
     "paper_id",
     "info",
@@ -77,9 +307,7 @@
     "table",
     "eq"
   ],
-
   "additionalProperties": false,
-
   "$defs": {
     "info": {
       "type": "object",
@@ -93,31 +321,61 @@
         "bibr_version"
       ],
       "properties": {
-        "title": { "type": ["string", "null"] },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "abstract": {
+          "description": "The paper's abstract, verbatim (finalized after section classification; may be recovered from front matter when no Abstract heading exists)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "keywords": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "doi": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^10\\.\\d{4,9}/\\S+$"
         },
         "file_hash": {
           "type": "string",
-          "pattern": "^[a-f0-9]{14}$"
+          "pattern": "^[a-f0-9]{14,16}$"
         },
         "input_format": {
           "type": "string",
           "enum": [
             "pdf",
             "docx",
+            "xml",
             "unknown"
           ]
         },
-        "file_name": { "type": "string" },
-        "bibr_version": { "type": "string" },
+        "file_name": {
+          "type": "string"
+        },
+        "schema_version": {
+          "description": "Version of this schema the file conforms to (10.3 renamed bibr_version to schema_version; 10.5 restored bibr_version alongside it)",
+          "type": "string"
+        },
+        "bibr_version": {
+          "description": "Version of the producing bibr package (e.g. 0.3.0). Before 10.3 this field held the schema version instead.",
+          "type": "string"
+        },
         "paper_type": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             "empirical",
             "review",
@@ -129,13 +387,19 @@
           ]
         },
         "paper_type_confidence": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 1
         },
         "oecd_l1": {
           "description": "OECD Research Area, Level 1",
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             "Natural Sciences",
             "Engineering and Technology",
@@ -148,7 +412,10 @@
         },
         "oecd_l2": {
           "description": "OECD Research Area, Level 2",
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             "Mathematics",
             "Computer and Information Sciences",
@@ -190,13 +457,98 @@
           ]
         },
         "oecd_confidence": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 1
+        },
+        "journal": {
+          "description": "The paper's own bibliographic identity, verbatim from the front matter (enrichment matches live in info_match)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volume": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "first_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issn": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "publisher": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "published": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "funding_statement": {
+          "description": "Verbatim funding statement, copied from the classified section body",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "coi_statement": {
+          "description": "Verbatim conflict-of-interest statement",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ethics_statement": {
+          "description": "Verbatim ethics/IRB statement",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data_availability": {
+          "description": "Verbatim data-availability statement",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
-
     "author": {
       "type": "object",
       "required": [
@@ -208,65 +560,128 @@
         "author_id": {
           "type": "integer"
         },
-        "given": { "type": ["string", "null"] },
-        "family": { "type": ["string", "null"] },
-        "affiliation": { "type": ["string", "null"] },
+        "given": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "family": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "affiliation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "email": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "email"
         },
-        "corresponding": { "type": "boolean" },
+        "corresponding": {
+          "type": "boolean"
+        },
         "orcid": {
           "description": "ORCID in canonical URI form: https://orcid.org/XXXX-XXXX-XXXX-XXXX",
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^https://orcid\\.org/\\d{4}-\\d{4}-\\d{4}-\\d{3}[\\dX]$"
         },
         "role": {
+          "description": "Contribution phrases mapped from the author-contributions statement (e.g. CRediT roles)",
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
-
     "text": {
       "type": "object",
-      "required": ["text", "text_id", "paragraph_id", "section_id"],
+      "required": [
+        "text",
+        "text_id",
+        "paragraph_id",
+        "section_id"
+      ],
       "properties": {
-        "text": { "type": "string" },
-        "text_id": { "type": "integer" },
-        "paragraph_id": { "type": "integer" },
+        "text": {
+          "type": "string"
+        },
+        "text_id": {
+          "type": "integer"
+        },
+        "paragraph_id": {
+          "type": "integer"
+        },
         "section_id": {
           "description": "References the section table; null when sentence belongs to root (pre-first-heading)",
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "page_number": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "The page number of the original document where the sentence starts (1-based)"
         },
         "formatted": {
           "description": "Original OCR representation for display formulas (e.g. LaTeX); or XML for grobid imports; null for regular text",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
-
     "section": {
       "type": "object",
-      "required": ["section_id", "header", "parent_section_id", "section_type"],
+      "required": [
+        "section_id",
+        "header",
+        "parent_section_id",
+        "section_type"
+      ],
       "properties": {
         "section_id": {
           "type": "integer",
           "description": "1-based unique section ID (section_id=0 is Root sentinel, excluded from export)"
         },
-        "header": { "type": "string" },
+        "header": {
+          "type": "string"
+        },
+        "level": {
+          "description": "Heading depth (1 = top-level)",
+          "type": "integer"
+        },
         "parent_section_id": {
           "description": "ID of the containing section; null for top-level sections",
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "section_type": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
+            "title",
             "abstract",
+            "keywords",
             "intro",
             "method",
             "results",
@@ -274,6 +689,11 @@
             "references",
             "acknowledgment",
             "funding",
+            "author_contributions",
+            "coi",
+            "ethics",
+            "open_data",
+            "appendix",
             "endnote",
             "footnote",
             "table",
@@ -283,51 +703,90 @@
           ]
         },
         "classification_score": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "minimum": 0,
           "maximum": 1
+        },
+        "classification_source": {
+          "description": "Which classifier tier produced section_type (e.g. alias, model, llm)",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
-
     "url": {
       "type": "object",
-      "required": ["href", "text_id"],
+      "required": [
+        "href",
+        "text_id"
+      ],
       "properties": {
         "href": {
           "type": "string",
           "format": "uri"
         },
-        "link_text": { "type": ["string", "null"] },
-        "text_id": { "type": "integer" }
+        "link_text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "text_id": {
+          "type": "integer"
+        }
       }
     },
-
     "bib_author": {
       "description": "Lightweight author representation for bibliography entries",
       "type": "object",
-      "required": ["given", "family"],
+      "required": [
+        "given",
+        "family"
+      ],
       "properties": {
-        "given": { "type": ["string", "null"] },
-        "family": { "type": ["string", "null"] }
+        "given": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "family": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       },
       "additionalProperties": false
     },
-
     "bib": {
       "type": "object",
-      "required": ["bib_id", "text_id"],
+      "required": [
+        "bib_id",
+        "text_id"
+      ],
       "properties": {
         "bib_id": {
           "type": "integer",
           "description": "1-based positional ID within the paper"
         },
         "text_id": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "The text table ID of the reference as written in the paper"
         },
         "bib_type": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             "journal_article",
             "book",
@@ -342,52 +801,133 @@
           ]
         },
         "doi": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^10\\.\\d{4,9}/\\S+$"
         },
-        "title": { "type": ["string", "null"] },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "authors": {
           "description": "Author names as they appear in the reference string",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "editors": {
           "description": "Editor names as they appear in the reference string",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "publisher": { "type": ["string", "null"] },
-        "year": { "type": ["integer", "null"] },
+        "publisher": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "year": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "year_suffix": {
           "description": "Disambiguator for same-author-year citations, e.g. 'a' in DeBruine (2005a)",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "date": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "date"
         },
         "container": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Journal or book title"
         },
-        "volume": { "type": ["string", "null"] },
-        "issue": { "type": ["string", "null"] },
-        "first_page": { "type": ["string", "null"] },
-        "last_page": { "type": ["string", "null"] },
-        "edition": { "type": ["string", "null"] },
-        "version": { "type": ["string", "null"] },
+        "volume": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "first_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "url": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "uri"
+        },
+        "is_in_press": {
+          "description": "Accepted but not yet issued; independent of year (a legacy year=0 sentinel also sets this)",
+          "type": "boolean"
+        },
+        "consolidated_fields": {
+          "description": "Comma-joined names of fields filled/replaced from bib_match by consolidation; absent on unconsolidated output",
+          "type": "string"
         }
       }
     },
-
     "bib_match": {
       "description": "Enrichment data from an external service for a bibliography entry",
-      "type": ["object", "null"],
-      "required": ["bib_id", "service"],
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "bib_id",
+        "service"
+      ],
       "properties": {
         "service": {
-          "type": ["string"],
+          "type": [
+            "string"
+          ],
           "enum": [
             "crossref",
             "openalex",
@@ -400,61 +940,352 @@
         },
         "bib_id": {
           "description": "Reference to the bib_id from the bib table",
-          "type": ["integer"]
+          "type": [
+            "integer"
+          ]
         },
         "service_id": {
           "description": "External identifier (DOI, OpenAlex ID, etc.)",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "score": {
           "description": "Match confidence score",
-          "type": ["number", "null"]
+          "type": [
+            "number",
+            "null"
+          ]
         },
-        "bib_type": { "type": ["string", "null"] },
+        "bib_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "doi": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^10\\.\\d{4,9}/\\S+$"
         },
-        "title": { "type": ["string", "null"] },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "authors": {
           "description": "Structured author list",
-          "type": ["array", "null"],
-          "items": { "$ref": "#/$defs/bib_author" }
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/bib_author"
+          }
         },
         "editors": {
           "description": "Structured editor list",
-          "type": ["array", "null"],
-          "items": { "$ref": "#/$defs/bib_author" }
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/bib_author"
+          }
         },
-        "publisher": { "type": ["string", "null"] },
-        "year": { "type": ["integer", "null"] },
+        "publisher": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "year": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "date": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "date"
         },
         "container": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Journal or book title"
         },
-        "volume": { "type": ["string", "null"] },
-        "issue": { "type": ["string", "null"] },
-        "first_page": { "type": ["string", "null"] },
-        "last_page": { "type": ["string", "null"] },
-        "edition": { "type": ["string", "null"] },
-        "version": { "type": ["string", "null"] },
+        "volume": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "first_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "url": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "uri"
         }
       }
     },
-
+    "info_match": {
+      "description": "Enrichment data from an external service for the paper's own identity; same shape as bib_match minus bib_id",
+      "type": "object",
+      "required": [
+        "service"
+      ],
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": [
+            "crossref",
+            "openalex",
+            "datacite",
+            "doi.org",
+            "openlibrary",
+            "manual",
+            "other"
+          ]
+        },
+        "service_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "bib_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "doi": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^10\\.\\d{4,9}/\\S+$"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "authors": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/bib_author"
+          }
+        },
+        "editors": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/bib_author"
+          }
+        },
+        "publisher": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "year": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "container": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volume": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "issue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "first_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_page": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      }
+    },
+    "funding": {
+      "description": "Structured funding entry parsed from the funding statement",
+      "type": "object",
+      "required": [
+        "funder"
+      ],
+      "properties": {
+        "funder": {
+          "type": "string"
+        },
+        "award_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "affiliation": {
+      "description": "Structured affiliation parsed from the author byline; text is verbatim, parsed components are best-effort",
+      "type": "object",
+      "required": [
+        "affiliation_id",
+        "text"
+      ],
+      "properties": {
+        "affiliation_id": {
+          "description": "1-based position",
+          "type": "integer"
+        },
+        "text": {
+          "type": "string"
+        },
+        "institution": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "department": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "city": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "author_ids": {
+          "description": "author_id values from the author table",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      }
+    },
     "xref": {
       "type": "object",
-      "required": ["xref_id", "xref_type", "contents", "text_id"],
+      "required": [
+        "xref_id",
+        "xref_type",
+        "contents",
+        "text_id"
+      ],
       "properties": {
         "xref_id": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "The ID from the bib, table, figure, or section table (for footnotes). Can be null if an xref does not match any bib/table/figure/footnote."
         },
         "xref_type": {
@@ -469,17 +1300,24 @@
             "section"
           ]
         },
-        "contents": { "type": ["string", "null"] },
+        "contents": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "text_id": {
           "type": "integer",
           "description": "The ID from the text table for the sentence containing the cross-reference"
         }
       }
     },
-
     "figure": {
       "type": "object",
-      "required": ["figure_id", "section_id"],
+      "required": [
+        "figure_id",
+        "section_id"
+      ],
       "properties": {
         "figure_id": {
           "description": "A unique ID for each figure (1-based)",
@@ -487,23 +1325,41 @@
         },
         "section_id": {
           "description": "The ID from the section table for this figure's caption section",
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "image": {
           "description": "Base64-encoded JPEG of the cropped figure region",
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "contentEncoding": "base64"
         },
+        "caption": {
+          "description": "The matched caption text",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "page_number": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Source page (1-based)"
         }
       }
     },
-
     "table": {
       "type": "object",
-      "required": ["table_id", "section_id"],
+      "required": [
+        "table_id",
+        "section_id"
+      ],
       "properties": {
         "table_id": {
           "description": "A unique ID for each table (1-based)",
@@ -511,30 +1367,54 @@
         },
         "section_id": {
           "description": "The ID from the section table for this table's caption section",
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "html": {
           "description": "The table contents as HTML",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "contents": {
           "description": "The table contents as tabular data: [headers_row, ...data_rows], all values stringified",
           "type": "array",
           "items": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           }
         },
+        "caption": {
+          "description": "The matched caption text",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "page_number": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Source page (1-based)"
         }
       }
     },
-
     "eq": {
       "type": "object",
-      "required": ["text_id", "grp_id", "lhs", "df", "comp", "rhs"],
+      "required": [
+        "text_id",
+        "grp_id",
+        "lhs",
+        "df",
+        "comp",
+        "rhs"
+      ],
       "properties": {
         "text_id": {
           "description": "ID from the text table for the source sentence",

--- a/tests/testthat/test-paper.R
+++ b/tests/testthat/test-paper.R
@@ -15,6 +15,21 @@ test_that(".paper_schema", {
   skip_on_cran()
   url <- "https://scienceverse.org/schema/paper.json"
   sv_schema <- jsonlite::read_json(url, simplifyVector = TRUE)
+
+  # metacheck bundles the published schema with ONE deliberate relaxation:
+  # `schema_version` is dropped from info.required so that papers produced by
+  # pre-10.5 bibr (which do not emit it) still validate. Pin that this is the
+  # *only* difference, then compare everything else for exact drift.
+  relaxed <- "schema_version"
+  expect_setequal(
+    setdiff(sv_schema$`$defs`$info$required, schema$`$defs`$info$required),
+    relaxed
+  )
+  expect_length(
+    setdiff(schema$`$defs`$info$required, sv_schema$`$defs`$info$required), 0
+  )
+  sv_schema$`$defs`$info$required <-
+    setdiff(sv_schema$`$defs`$info$required, relaxed)
   expect_equal(schema, sv_schema)
 })
 


### PR DESCRIPTION
## Summary

Syncs metacheck's bundled `inst/schema/paper.json` to the published bibr **v10.5** schema (`scienceverse.org/schema/paper.json`), which moved to 10.5 when [scienceverse/schema#1](https://github.com/scienceverse/schema/pull/1) merged. This un-reds the project-wide `.paper_schema` test.

## Why it was red

`test-paper.R`'s `.paper_schema` asserts the bundled schema equals the published contract:

```r
expect_equal(.paper_schema(), jsonlite::read_json("https://scienceverse.org/schema/paper.json", simplifyVector = TRUE))
```

The publish moved the remote to v10.5 (adds `$defs`: `funding`, `affiliation`, `info_match`; `table.caption`; and many new `info` fields) while the bundled copy still self-described as **v10.0**. Bundled ≠ remote → the test failed on every branch. metacheck's test CI only runs on push to `main`, so this didn't surface as a red check on PRs into `dev`.

## The one deliberate divergence

v10.5 adds `schema_version` to `info.required`. metacheck must ingest **historical** papers — `psychsci`, `demopaper()`, and user-supplied PDFs — produced by pre-10.5 bibr, which emit `bibr_version` but **not** `schema_version`. Because `paper_validate()` hard-*errors* on any missing required column, a byte-for-byte sync would break ~30 validation assertions across `test-paper` / `test-psychsci` / `test-import-*`.

So the bundled schema is the published v10.5 **with exactly one relaxation**: `schema_version` dropped from `info.required` (every fixture still satisfies the remaining requireds, including `bibr_version`). Fresh `paper()` objects still gain all 27 `info` columns, because the constructor builds columns from `properties`, not `required`.

## Test change (justified, not weakened)

`.paper_schema` previously asserted byte-exact equality with remote. It now:

1. pins that `schema_version` is the **only** field the bundled schema drops from `info.required`, and that bundled adds nothing the remote lacks, then
2. compares everything else for exact structural equality.

It still catches any *unintended* drift — it only tolerates the single documented relaxation.

## Verification

- `.paper_schema` passes online against the live remote.
- Full suite green: **0 failed, 0 warnings, 2724 passed** (38 skipped) — verified on both the `dev` base and the `jw_fable_fixes` base.
- `bibr_version` stamping (`import-grobid.R:293` reads it from `schema$description`) now yields `10.5`. The `convert()`-regenerated `fixtures/problems/203020.json` churn is a pre-existing test artifact (the test overwrites a tracked fixture on every run) and is intentionally left untracked here.

https://claude.ai/code/session_01YLqyRiqzyaZncJ3m5VcjxK
