### PR TITLE
fix(grobid): stop anchor normalization from corrupting paper text

### DIFF
--- a/R/import-grobid.R
+++ b/R/import-grobid.R
@@ -451,7 +451,11 @@ grobid_to_bibr <- function(xml_path,
   paper$url$href <- gsub("\\.$", "", paper$url$href) # fix urls with . at end
   same <- gsub("^https?://", "", paper$url$href) ==
     gsub("^https?://", "", gsub("\\s", "", paper$url$link_text))
-  for (i in seq_along(same)) {
+  same <- !is.na(same) & same
+  # only normalize anchors that ARE the URL (modulo spaces/protocol):
+  # substituting arbitrary anchor text with its href rewrites every match of
+  # that text in the whole paper (e.g. anchor "Fig" clobbering "Fig. 2")
+  for (i in which(same)) {
     paper$text$text <- gsub(paper$url$link_text[[i]],
          paper$url$href[[i]],
          paper$text$text, fixed = TRUE)


### PR DESCRIPTION
Standalone extraction from #329 (splitting the large Fable-audit PR into small, per-concern PRs).

## Problem
`grobid_to_bibr()` normalizes link anchor text to its href by running `gsub(anchor, href, paper$text$text, fixed = TRUE)` for **every** URL. Two bugs:
- The loop iterated `seq_along(same)` including `NA` comparisons.
- It substituted *arbitrary* anchor text globally, so a short anchor like `"Fig"` rewrote every match of that string in the whole paper (e.g. clobbering `"Fig. 2"`) — silent text corruption in the parsed paper.

## Fix
Only normalize anchors that **are** the URL (modulo whitespace/protocol), and drop `NA`s:
```r
same <- !is.na(same) & same
for (i in which(same)) { ... }
```

Single file, no API/behavioural change beyond correctness. Full suite was green with this change as part of #329 (0 failed / 2724 passed).

https://claude.ai/code/session_01YLqyRiqzyaZncJ3m5VcjxK