### PR TITLE
feat(read): let bibr abstract and figure/table captions flow through

### DIFF
--- a/R/import-read.R
+++ b/R/import-read.R
@@ -72,7 +72,6 @@ read <- function(file_path, include_images = FALSE, recursive = FALSE) {
   info[zeros] <- NA
   paper$info <- as.data.frame(info)
   paper$info$keywords <- I(list(keywords))
-  paper$info$abstract <- NULL # TODO: remove after bibr fixed
 
   # author ----
   if (!is.null(data$author) && length(data$author) > 0) {
@@ -100,7 +99,6 @@ read <- function(file_path, include_images = FALSE, recursive = FALSE) {
     if (!include_images) {
       paper$figure$image <- NA_character_
     }
-    paper$figure$caption <- NULL #tempfix
   }
 
   # url ----
@@ -118,7 +116,6 @@ read <- function(file_path, include_images = FALSE, recursive = FALSE) {
   # table ----
   if (!is.null(data$table) && length(data$table) > 0) {
     paper$table <- as.data.frame(data$table)
-    paper$table$caption <- NULL #tempfix
   }
 
   # text ----


### PR DESCRIPTION
Standalone extraction from #329 (splitting the large Fable-audit PR into small, per-concern PRs). Part of the bibr track alongside the schema sync #330.

## Change
`read()` stripped three fields with leftover "tempfix" NULL assignments:
```r
paper$info$abstract <- NULL   # TODO: remove after bibr fixed
paper$figure$caption <- NULL  # tempfix
paper$table$caption <- NULL   # tempfix
```
bibr now emits `abstract` and figure/table `caption`, so these lines discard real data. Removing them lets the fields flow through.

## Safety on the current (v10.0) bundled schema
- `paper_validate()` only errors on **missing required** columns — these are not required, so keeping them is fine.
- `.paper_coerce()` only coerces columns it knows about and leaves others untouched.

Verified on the `dev` base: read + paper tests pass with **zero new failures**. (The one pre-existing `.paper_schema` failure is the bundled-v10.0-vs-live-remote-v10.5 drift that #330 fixes; it is red on clean `dev` too and is unrelated to this change.)

Pairs with #330, which adds the matching `caption` `$defs` to the bundled schema.

https://claude.ai/code/session_01YLqyRiqzyaZncJ3m5VcjxK