### PR TITLE
feat(plumber): bibr-JSON REST API — validated uploads, HTML report, hardened runtime

### DIFF
--- a/inst/demos/golden_bibr_10_2.json
+++ b/inst/demos/golden_bibr_10_2.json
@@ -1,0 +1,42 @@
+{
+  "paper_id": "golden-demo",
+  "info": {
+    "bibr_version": "10.2.0",
+    "title": "To Err Is Human: A Golden Contract Demonstration",
+    "doi": "10.0000/golden.demo",
+    "keywords": ["errors", "statistics", "contract-test"],
+    "description": "Synthetic fixture pinning the bibr JSON contract."
+  },
+  "author": [
+    {"given": "Jane", "surname": "Doe", "orcid": "0000-0000-0000-0001"},
+    {"given": "Joe", "surname": "Bloggs", "orcid": null}
+  ],
+  "text": [
+    {"text": "We tested whether errors are human.", "section": "intro", "header": "Introduction", "div": 1, "p": 1, "s": 1},
+    {"text": "The effect was significant, t(48) = 2.10, p = 0.041.", "section": "results", "header": "Results", "div": 2, "p": 1, "s": 1},
+    {"text": "Data are available at https://osf.io/golden.", "section": "results", "header": "Results", "div": 2, "p": 2, "s": 1}
+  ],
+  "section": [
+    {"section": "intro", "header": "Introduction", "div": 1},
+    {"section": "results", "header": "Results", "div": 2}
+  ],
+  "url": [
+    {"href": "https://osf.io/golden", "link_text": "https://osf.io/golden", "text_id": 3}
+  ],
+  "bib": [
+    {"bib_id": 1, "ref": "Doe, J. (2020). Prior work. Journal of Demos, 1(1), 1-10.", "doi": "10.1000/xyz", "title": "Prior work", "year": 2020}
+  ],
+  "xref": [
+    {"bib_id": 1, "text": "(Doe, 2020)", "div": 1, "p": 1, "s": 1}
+  ],
+  "figure": [
+    {"figure_id": 1, "caption": "A demonstration figure.", "image": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}
+  ],
+  "table": [],
+  "eq": [],
+  "bib_match": [],
+  "processing_warnings": [],
+  "_regions": [
+    {"page": 1, "bbox": [0, 0, 100, 100]}
+  ]
+}

--- a/inst/plumber/Dockerfile
+++ b/inst/plumber/Dockerfile
@@ -26,6 +26,27 @@ RUN apt-get update && apt-get install -y \
 RUN R -e "install.packages(c('remotes', 'plumber'))"
 RUN R -e "remotes::install_cran(c('dplyr', 'tidyr', 'logger', 'progress', 'tidytext', 'SnowballC', 'xml2', 'statcheck', 'httr', 'httr2', 'jsonlite', 'quarto', 'knitr', 'arrow', 'ellmer', 'rvest', 'officer', 'DT', 'bibtex', 'bib2df', 'roxygen2', 'gitcreds', 'anytime', 'htmltools', 'base64enc', 'urltools', 'fs', 'rappdirs', 'curl'))"
 
+# Quarto CLI — report() renders the HTML report via quarto::quarto_render().
+# The `quarto` R package (installed above) is only a wrapper around this binary,
+# which rocker/r-ver does not ship. Download it with R (libcurl) so we don't add
+# a curl CLI to the image. The version is pinned for reproducible builds (bump
+# QUARTO_VERSION deliberately); the `quarto --version` at the end fails the build
+# loudly if the install is broken. HTML-only output → no TinyTeX/LaTeX needed.
+ARG QUARTO_VERSION=1.9.38
+RUN R -e "download.file('https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb', '/tmp/quarto.deb', quiet = TRUE)" \
+    && apt-get update && apt-get install -y /tmp/quarto.deb \
+    && rm -rf /var/lib/apt/lists/* /tmp/quarto.deb \
+    && quarto --version
+
+# In the production deployment the container runs with a read-only root
+# filesystem and only /tmp writable (a tmpfs — see docker-compose.yml), so point
+# every transient Quarto/Deno write at it. Without this, quarto_render can't
+# create its caches at runtime and the HTML render fails (gracefully — the JSON
+# check still succeeds — but no report is produced).
+ENV XDG_CACHE_HOME=/tmp/.cache \
+    DENO_DIR=/tmp/.deno \
+    TMPDIR=/tmp
+
 # copy app
 COPY . /srv/metacheck
 WORKDIR /srv/metacheck

--- a/inst/plumber/README.md
+++ b/inst/plumber/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the Plumber API for the metacheck package.
 
-The API wraps metacheck functionality to provide endpoints that can be accessed via HTTP requests, accepting GROBID XML files and mostly optional parameters.
+The API wraps metacheck functionality to provide endpoints that can be accessed via HTTP requests, accepting bibr JSON files and mostly optional parameters.
 
 This enables the use metacheck as a web service, as part of various pipelines, with other services, or a with a frontend.
 
@@ -50,52 +50,71 @@ inst/plumber/
 
 ### Paper Analysis (`/paper/*`)
 
-These endpoints all accept **uploaded GROBID XML files** for analysis:
+All `POST` endpoints accept **uploaded bibr JSON files** for analysis:
 
+- `GET  /paper/modules` - List the metacheck modules this API can run (no upload)
 - `POST /paper/info` - Extract paper information (title, keywords, DOI, etc.)
 - `POST /paper/authors` - Get author table
 - `POST /paper/references` - Get bibliography/references
 - `POST /paper/cross-references` - Get in-text citation cross-references
-- `POST /paper/search` - Search text within the paper (requires `q` parameter)
+- `POST /paper/search` - Search text within the paper (requires `pattern` parameter)
 - `POST /paper/module` - Run a specific metacheck module on the paper (requires `name` parameter)
-- `POST /paper/check` - Get all metadata + run all/select metacheck modules on the paper (optional `modules` parameter)
+- `POST /paper/check` - Get all metadata + run all/select metacheck modules on the paper (optional `modules` and `report` parameters)
 
 
 ## Key Features
 
-### GROBID XML Input
+### bibr JSON Input
 
-Paper analysis endpoints accept **GROBID XML files** which are directly analyzed with `metacheck::read_grobid()`. You can get the GROBID TEI XML by processing PDFs with a GROBID server, for example using the pdf2grobid in metacheck function,
-(not available in the API due to strategic reasons) or the official GROBID client.
+Paper analysis endpoints accept **bibr JSON files** — the output of the
+[bibr](https://github.com/scienceverse/bibr) extraction pipeline
+(`POST /papers/extract`). They are read with metacheck's internal bibr
+reader. GROBID XML is no longer accepted by the API (the metacheck R package
+still reads it via `read()`).
 
 ### Module Support
 
 Shadows the available metacheck modules as API endpoints.
-The `/paper/module` endpoint allows you to run any metacheck module dynamically. Available modules are automatically detected from the package installation.
+The `/paper/module` endpoint allows you to run any metacheck module dynamically. Available modules are automatically detected from the package installation, and `GET /paper/modules` returns that list (the same names `/module` and `/check` validate against).
 You can also use the `/paper/check` endpoint to run multiple/all available checking modules at once.
+
+By default `/paper/check` also renders metacheck's native HTML report (via Quarto) and returns it as `report_html`. This is the most expensive part of the call; pass `report=false` to skip the render and get the JSON results only.
+
+## LLM configuration
+
+Set `GEMINI_API_KEY` to enable LLM-backed modules (provider
+`google_gemini`). Optional: `METACHECK_LLM_MODEL` (default
+`google_gemini/gemini-3.1-flash-lite-preview`) and `METACHECK_LLM_MAX_CALLS`
+(default 200). Without the key, LLM modules fall back to non-LLM behavior.
 
 ## Example Usage
 
-### Analyze a GROBID XML File
+### List Available Modules
+
+```bash
+curl http://localhost:2005/paper/modules
+```
+
+### Analyze a bibr JSON File
 
 ```bash
 curl -X POST http://localhost:2005/paper/info \
-  -F "file=@paper.xml" \
+  -F "file=@paper.json" \
   -F "fields=title,doi,keywords"
 ```
 
-### Get Authors from XML
+### Get Authors from JSON
 
 ```bash
 curl -X POST http://localhost:2005/paper/authors \
-  -F "file=@paper.xml"
+  -F "file=@paper.json"
 ```
 
 ### Search Paper Text
 
 ```bash
 curl -X POST http://localhost:2005/paper/search \
-  -F "file=@paper.xml" \
+  -F "file=@paper.json" \
   -F "pattern=statistics"
 ```
 
@@ -103,7 +122,7 @@ curl -X POST http://localhost:2005/paper/search \
 
 ```bash
 curl -X POST http://localhost:2005/paper/module \
-  -F "file=@paper.xml" \
+  -F "file=@paper.json" \
   -F "name=ref_doi_check"
 ```
 
@@ -112,12 +131,17 @@ curl -X POST http://localhost:2005/paper/module \
 ```bash
 # Run all available modules
 curl -X POST http://localhost:2005/paper/check \
-  -F "file=@paper.xml"
+  -F "file=@paper.json"
 
 # Run specific modules
 curl -X POST http://localhost:2005/paper/check \
-  -F "file=@paper.xml" \
+  -F "file=@paper.json" \
   -F "modules=stat_p_exact,stat_check"
+
+# Skip the (expensive) HTML report render — JSON results only
+curl -X POST http://localhost:2005/paper/check \
+  -F "file=@paper.json" \
+  -F "report=false"
 ```
 
 
@@ -129,6 +153,4 @@ Main entry point that mounts endpoint groups.
 
 ### `endpoints/paper.R`
 
-Paper analysis endpoints - handles GROBID XML file uploads, reads papers via `read_paper()`, and runs metacheck functions/modules.
-
-
+Paper analysis endpoints - handles bibr JSON file uploads, reads papers via `read_paper()`, and runs metacheck functions/modules.

--- a/inst/plumber/api.R
+++ b/inst/plumber/api.R
@@ -1,17 +1,53 @@
 # api.R
 # Plumber API for metacheck
-# Supports both single-paper analysis and GROBID processing
+# Accepts bibr JSON uploads for single-paper analysis
 
 library(plumber)
 library(metacheck)
 
+# --- LLM configuration (env-driven, per-deploy) -----------------------------
+# Load-bearing: metacheck.llm.use defaults to FALSE and the LLM-using modules
+# silently fall back to non-LLM paths — without this block the LLM half of
+# the API is dead with no error.
+#
+# GEMINI_API_KEY, not GOOGLE_API_KEY: metacheck maps GOOGLE_API_KEY to the
+# google_vertex provider (needs a GCP project; errors on a bare API key);
+# google_gemini is the provider that works with AI-Studio keys.
+if (nzchar(Sys.getenv("GEMINI_API_KEY"))) {
+  metacheck::llm_use(TRUE)
+  model_str <- Sys.getenv("METACHECK_LLM_MODEL", "")
+  metacheck::llm_model(if (nzchar(model_str)) model_str
+                       else "google_gemini/gemini-3.1-flash-lite-preview")
+  # default llm_max_calls is 30 and llm() *errors* (not truncates) past it —
+  # too low for big papers
+  max_calls_str <- Sys.getenv("METACHECK_LLM_MAX_CALLS", "")
+  metacheck::llm_max_calls(if (nzchar(max_calls_str)) as.integer(max_calls_str) else 200L)
+  logger::log_info("LLM enabled: {metacheck::llm_model()}")
+} else {
+  logger::log_info("GEMINI_API_KEY not set — LLM modules will use fallbacks")
+}
+
 #* @apiTitle metacheck API
-#* @apiDescription API for analyzing academic papers. Upload GROBID TEI XML to extract metadata, authors, references, and more.
+#* @apiDescription API for analyzing academic papers. Upload bibr JSON (from the bibr extraction pipeline) to extract metadata, authors, references, and run metacheck modules.
 
 #* @plumber
 function(pr) {
-  # Paper analysis endpoints - upload XML to analyze
-  plumber::pr_mount(pr, "/paper", plumber::pr("endpoints/paper.R"))
+  # Paper analysis endpoints - upload bibr JSON to analyze.
+  #
+  # The restricted parser set is load-bearing: each handler parses the
+  # multipart upload itself (mime::parse_multipart) and reads the file with
+  # .read_bibr. "multi" must stay registered — plumber's body-read step feeds
+  # rook.input, and without it mime sees an empty body and every upload 500s
+  # (the "none" parser breaks exactly this way). Restricting the inner parsers
+  # to "octet" keeps file parts as raw bytes: with plumber's defaults the
+  # application/json file part (the Content-Type clients set for a .json
+  # upload) would be JSON-parsed a *second* time — wasteful on payloads up to
+  # the 50MB cap — and a malformed body would throw an uncaught 500 in
+  # plumber's parse phase, before the handler's read_paper()/error_response()
+  # can turn it into a clean 400.
+  paper_pr <- plumber::pr("endpoints/paper.R")
+  plumber::pr_set_parsers(paper_pr, c("multi", "octet"))
+  plumber::pr_mount(pr, "/paper", paper_pr)
 }
 
 #* Health check endpoint

--- a/inst/plumber/docker-compose.yml
+++ b/inst/plumber/docker-compose.yml
@@ -5,5 +5,16 @@ services:
       dockerfile: inst/plumber/Dockerfile
     ports:
       - "2005:2005"
-    volumes:
-      - .:/srv/metacheck
+    # Match the runtime the Dockerfile's cache-dir ENV is written for: an
+    # immutable root filesystem with only /tmp (a tmpfs) writable, where Quarto/
+    # Deno caches and parsed uploads go. Keeps the image's installed package
+    # authoritative (no source bind-mount shadowing /srv/metacheck).
+    read_only: true
+    tmpfs:
+      - /tmp:size=512m
+    # Optional LLM config, passed through from the host environment. Without
+    # GEMINI_API_KEY the LLM-backed modules fall back to non-LLM behaviour.
+    environment:
+      - GEMINI_API_KEY
+      - METACHECK_LLM_MODEL
+      - METACHECK_LLM_MAX_CALLS

--- a/inst/plumber/endpoints/paper.R
+++ b/inst/plumber/endpoints/paper.R
@@ -1,5 +1,5 @@
 # endpoints/paper.R
-# Paper analysis endpoints - can work with uploaded PDFs or GROBID XML
+# Paper analysis endpoints - accept bibr JSON uploads
 
 library(metacheck)
 library(logger)
@@ -17,153 +17,75 @@ AVAILABLE_MODULES <- list.files(
 
 logger::log_info("Loaded {length(AVAILABLE_MODULES)} modules: {paste(AVAILABLE_MODULES, collapse = ', ')}")
 
+# Parse the optional comma-separated `modules` form field into a character
+# vector, defaulting to every available module. Defined here (not in helpers.R)
+# because it closes over AVAILABLE_MODULES.
+.parse_modules <- function(modules_param) {
+    if (!is.null(modules_param) && nzchar(modules_param)) {
+        trimws(strsplit(modules_param, ",")[[1]])
+    } else {
+        AVAILABLE_MODULES
+    }
+}
+
+#* List the metacheck modules this API can run
+#* @get /modules
+#* @serializer json
+function() {
+    # The authoritative whitelist /module and /check validate against, so
+    # discovery matches enforcement exactly.
+    list(modules = AVAILABLE_MODULES, count = length(AVAILABLE_MODULES))
+}
+
 #* Process a paper and return info table
 #* @post /info
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @param fields:[string] Comma-separated fields to include (optional, e.g., "title,keywords,doi,description")
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (info): {request_id}")
-    # Parse multipart form data
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
-
-    # Validate file upload
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
-
-    # Save the uploaded file as a temporary file, then unlink after processing
-    #
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-
-    # Read paper
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    # Parse fields parameter
-    fields <- if (!is.null(mp$fields)) {
-        strsplit(mp$fields, ",")[[1]]
-    } else {
-        c("title", "keywords", "doi", "description")
-    }
-
-    info_table(paper_obj$paper, fields)
+    with_uploaded_paper(req, res, "info", function(paper, mp, request_id) {
+        fields <- if (!is.null(mp$fields)) {
+            strsplit(mp$fields, ",")[[1]]
+        } else {
+            c("title", "keywords", "doi", "description")
+        }
+        info_fields(paper, fields)
+    })
 }
 
 #* Get author table from a paper
 #* @post /authors
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (authors): {request_id}")
-
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
-
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
-
-    # Save the uploaded file as a temporary file, then unlink after processing
-    #
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    paper_table(paper_obj$paper, "author")
+    with_uploaded_paper(req, res, "authors", function(paper, mp, request_id) {
+        paper_table(paper, "author")
+    })
 }
 
 #* Get references from a paper
 #* @post /references
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (references): {request_id}")
-
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
-
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
-
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    #
-    # Save the uploaded file as a temporary file, then unlink after processing
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    paper_obj$paper$bib
+    with_uploaded_paper(req, res, "references", function(paper, mp, request_id) {
+        paper$bib
+    })
 }
 
 #* Get cross-references from a paper
 #* @post /cross-references
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (cross-references): {request_id}")
-
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
-
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
-
-    # Save the uploaded file as a temporary file, then unlink after processing
-    #
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    paper_obj$paper$xref
+    with_uploaded_paper(req, res, "cross-references", function(paper, mp, request_id) {
+        paper$xref
+    })
 }
 
 #* Search text in a paper
 #* @post /search
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @param pattern the regex pattern to search for (required)
 #* @param section the section(s) to search in (optional)
 #* @param return the kind of text to return: "sentence", "paragraph", "div", "section", "match", or "paper_id" (optional, defaults to "sentence")
@@ -172,169 +94,139 @@ function(req, res) {
 #* @param perl logical. Should Perl-compatible regexps be used? (optional, defaults to FALSE)
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (search): {request_id}")
+    with_uploaded_paper(
+        req, res, "search",
+        prevalidate = function(mp) {
+            # Reject a missing pattern before paying the bibr parse cost.
+            if (is.null(mp$pattern) || mp$pattern == "") {
+                list(status = 400, message = "Query parameter 'pattern' is required")
+            }
+        },
+        handler = function(paper, mp, request_id) {
+            # Prepare optional parameters with defaults
+            search_params <- list(paper = paper, pattern = mp$pattern)
 
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
+            if (!is.null(mp$section)) search_params$section <- mp$section
+            if (!is.null(mp$return)) search_params$return <- mp$return
+            if (!is.null(mp$ignore.case)) search_params$ignore.case <- as.logical(mp$ignore.case)
+            if (!is.null(mp$fixed)) search_params$fixed <- as.logical(mp$fixed)
+            if (!is.null(mp$perl)) search_params$perl <- as.logical(mp$perl)
 
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
-
-    # Save the uploaded file as a temporary file, then unlink after processing
-    #
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-    if (is.null(mp$pattern) || mp$pattern == "") {
-        return(error_response(res, 400, "Query parameter 'pattern' is required"))
-    }
-
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    # Prepare optional parameters with defaults
-    search_params <- list(
-        paper = paper_obj$paper,
-        pattern = mp$pattern
+            do.call(text_search, search_params)
+        }
     )
-
-    if (!is.null(mp$section)) search_params$section <- mp$section
-    if (!is.null(mp$return)) search_params$return <- mp$return
-    if (!is.null(mp$ignore.case)) search_params$ignore.case <- as.logical(mp$ignore.case)
-    if (!is.null(mp$fixed)) search_params$fixed <- as.logical(mp$fixed)
-    if (!is.null(mp$perl)) search_params$perl <- as.logical(mp$perl)
-
-    do.call(text_search, search_params)
 }
-
 
 #* Run a specific module on the paper
 #* @post /module
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @param name:[string] Name of the module to run (required)
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (module): {request_id}")
-
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
-
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
-
-    # Save the uploaded file as a temporary file, then unlink after processing
-    #
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-    if (is.null(mp$name) || mp$name == "") {
-        return(error_response(res, 400, "Module name parameter 'name' is required"))
-    }
-
-    if (!(mp$name %in% AVAILABLE_MODULES)) {
-        return(error_response(res, 400, paste0("Module '", mp$name, "' not found. Available modules: ", paste(AVAILABLE_MODULES, collapse = ", "))))
-    }
-
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    # Dynamically source and run the module
-    module_path <- system.file("modules", paste0(mp$name, ".R"), package = "metacheck")
-    if (module_path == "") {
-        return(error_response(res, 500, paste0("Module file for '", mp$name, "' not found.")))
-    }
-
-    source(module_path, local = TRUE)
-    if (!exists(mp$name)) {
-        return(error_response(res, 500, paste0("Module '", mp$name, "' does not define a '", mp$name, "' function.")))
-    }
-
-    tryCatch(
-        {
-            result <- get(mp$name)(paper_obj$paper)
-            result
+    with_uploaded_paper(
+        req, res, "module",
+        prevalidate = function(mp) {
+            # Validate the module name against the whitelist before parsing.
+            if (is.null(mp$name) || mp$name == "") {
+                return(list(status = 400, message = "Module name parameter 'name' is required"))
+            }
+            if (!(mp$name %in% AVAILABLE_MODULES)) {
+                return(list(status = 400, message = paste0(
+                    "Module '", mp$name, "' not found. Available modules: ",
+                    paste(AVAILABLE_MODULES, collapse = ", ")
+                )))
+            }
+            NULL
         },
-        error = function(e) {
-            error_response(res, 500, paste0("Error running module '", mp$name, "': ", e$message))
+        handler = function(paper, mp, request_id) {
+            # Dynamically source and run the (whitelisted) module
+            module_path <- system.file("modules", paste0(mp$name, ".R"), package = "metacheck")
+            if (module_path == "") {
+                return(error_response(res, 500, paste0("Module file for '", mp$name, "' not found.")))
+            }
+
+            source(module_path, local = TRUE)
+            if (!exists(mp$name)) {
+                return(error_response(res, 500, paste0("Module '", mp$name, "' does not define a '", mp$name, "' function.")))
+            }
+
+            tryCatch(
+                {
+                    result <- get(mp$name)(paper)
+                    # Strip S3 classes jsonlite can't encode (e.g. `ellmer_output`
+                    # columns from LLM modules) before the response is serialized.
+                    json_safe(result)
+                },
+                error = function(e) {
+                    error_response(res, 500, paste0("Error running module '", mp$name, "': ", e$message))
+                }
+            )
         }
     )
 }
 
 #* Get all relevant metadata from a paper, and run metacheck modules on it
 #* @post /check
-#* @param file:file GROBID XML file to process
+#* @param file:file bibr JSON file to process
 #* @param modules:[string] Comma-separated list of modules to run (optional, defaults to all)
+#* @param report whether to render metacheck's HTML report (optional, "true"/"false", defaults to TRUE; "false" skips the Quarto render and returns "" for report_html)
 #* @serializer json
 function(req, res) {
-    request_id <- uuid::UUIDgenerate()
-    logger::log_info("Request started (check): {request_id}")
+    with_uploaded_paper(
+        req, res, "check",
+        prevalidate = function(mp) {
+            # Validate requested modules against the whitelist before parsing.
+            invalid_modules <- setdiff(.parse_modules(mp$modules), AVAILABLE_MODULES)
+            if (length(invalid_modules) > 0) {
+                list(status = 400, message = paste0(
+                    "Invalid modules: ", paste(invalid_modules, collapse = ", "),
+                    ". Available modules: ", paste(AVAILABLE_MODULES, collapse = ", ")
+                ))
+            }
+        },
+        handler = function(paper, mp, request_id) {
+            modules <- .parse_modules(mp$modules)
+            include_report <- parse_bool(mp$report, default = TRUE)
 
-    mp <- mime::parse_multipart(req)
-    uploaded_file <- extract_uploaded_file(mp)
+            logger::log_info("Paper processed successfully, extracting metadata: {request_id}")
+            authors <- paper_table(paper, "author")
+            references <- paper$bib
+            cross_references <- paper$xref
 
-    validation <- validate_file_upload(uploaded_file)
-    if (!validation$valid) {
-        return(error_response(res, validation$status, validation$message))
-    }
+            logger::log_info("Running {length(modules)} module(s): {paste(modules, collapse = ', ')} - {request_id}")
+            # Run each module once, keeping the FULL metacheck_module_output object: the
+            # HTML report renderer needs fields (e.g. $section) that the JSON-safe view
+            # below drops. A per-module failure is contained as a synthetic fail object,
+            # so one bad module sinks neither the JSON response nor the rendered report.
+            full_output <- lapply(modules, function(module_name) {
+                tryCatch(
+                    module_run(paper, module_name),
+                    error = function(e) {
+                        structure(
+                            list(
+                                module = module_name,
+                                title = module_name,
+                                table = NULL,
+                                summary_table = NULL,
+                                summary_text = "Error running module",
+                                report = paste0("Error running module '", module_name, "': ", e$message),
+                                traffic_light = "fail",
+                                section = "general"
+                            ),
+                            class = "metacheck_module_output"
+                        )
+                    }
+                )
+            })
+            names(full_output) <- modules
 
-    # Save the uploaded file as a temporary file, then unlink after processing
-    #
-    # This block may seem redundant to have in every endpoint, but harder than
-    # expected to abstract it away
-    tmp_xml <- tempfile(fileext = ".xml")
-    on.exit(unlink(tmp_xml), add = TRUE)
-    file.copy(uploaded_file, tmp_xml)
-    uploaded_file <- tmp_xml
-
-    # Parse modules parameter
-    modules <- if (!is.null(mp$modules) && mp$modules != "") {
-        strsplit(mp$modules, ",")[[1]] |> trimws()
-    } else {
-        AVAILABLE_MODULES
-    }
-
-    # Validate that all requested modules exist
-    invalid_modules <- setdiff(modules, AVAILABLE_MODULES)
-    if (length(invalid_modules) > 0) {
-        return(error_response(res, 400, paste0("Invalid modules: ", paste(invalid_modules, collapse = ", "), ". Available modules: ", paste(AVAILABLE_MODULES, collapse = ", "))))
-    }
-
-    paper_obj <- read_paper(uploaded_file, request_id)
-    if (!paper_obj$success) {
-        return(error_response(res, 500, paper_obj$error))
-    }
-
-    logger::log_info("Paper processed successfully, extracting metadata: {request_id}")
-    authors <- paper_table(paper_obj$paper, "author")
-    references <- paper_obj$paper$bib
-    cross_references <- paper_obj$paper$xref
-
-    logger::log_info("Running {length(modules)} module(s): {paste(modules, collapse = ', ')} - {request_id}")
-    # Run all requested modules using module_run
-    module_output <- lapply(modules, function(module_name) {
-        tryCatch(
-            {
-                result <- module_run(paper_obj$paper, module_name)
-                # Convert metacheck_module_output to plain list for JSON serialization
-                list(
+            # JSON-safe view for the API response: plain lists with only the
+            # serialisable fields (metacheck_module_output objects don't round-trip).
+            # json_safe() also strips S3 classes jsonlite can't encode (e.g. the
+            # `ellmer_output` columns LLM modules embed in their tables) — without it
+            # the whole response aborts with "No method asJSON S3 class: ellmer_output".
+            module_output <- lapply(full_output, function(result) {
+                json_safe(list(
                     module = result$module,
                     title = result$title,
                     table = result$table,
@@ -342,36 +234,36 @@ function(req, res) {
                     summary_text = result$summary_text,
                     report = result$report,
                     traffic_light = result$traffic_light
-                )
-            },
-            error = function(e) {
-                list(
-                    module = module_name,
-                    title = module_name,
-                    table = NULL,
-                    summary_table = NULL,
-                    summary_text = "Error running module",
-                    report = paste0("Error running module '", module_name, "': ", e$message),
-                    traffic_light = "fail"
-                )
+                ))
+            })
+
+            # metacheck's native HTML report, rendered from the modules just run (NO
+            # re-run, no extra LLM calls). Best-effort: "" when Quarto can't render it,
+            # which the platform treats as "no HTML available" (the JSON check is
+            # unaffected). Skipped entirely when report=false so JSON-only clients
+            # don't pay the (multi-second, single-threaded) Quarto render.
+            report_html <- if (include_report) {
+                render_report_html(full_output, paper, request_id)
+            } else {
+                logger::log_info("Report render skipped (report=false): {request_id}")
+                ""
             }
-        )
-    })
 
-    # Set module names as keys
-    names(module_output) <- modules
-
-    logger::log_info("Request completed successfully: {request_id}")
-    # Return the aggregated report
-    list(
-        paper_info = info_table(
-            paper_obj$paper,
-            c("title", "keywords", "doi", "submission", "received", "accepted")
-        ),
-        authors = authors,
-        references = references,
-        cross_references = cross_references,
-        modules_run = modules,
-        results = module_output
+            logger::log_info("Request completed successfully: {request_id}")
+            # Return the aggregated report
+            list(
+                metacheck_version = as.character(utils::packageVersion("metacheck")),
+                paper_info = info_fields(
+                    paper,
+                    c("title", "keywords", "doi", "submission", "received", "accepted")
+                ),
+                authors = authors,
+                references = references,
+                cross_references = cross_references,
+                modules_run = modules,
+                results = module_output,
+                report_html = report_html
+            )
+        }
     )
 }

--- a/inst/plumber/utils/helpers.R
+++ b/inst/plumber/utils/helpers.R
@@ -1,12 +1,41 @@
 # helpers.R
 # Helper functions for plumber API
 
-#' Normalize zero-length values to NULL
+# Classes the JSON serializer (jsonlite, via plumber's `@serializer json`)
+# knows how to encode. Anything else must be stripped before it reaches the
+# response or serialization aborts the whole request.
+.JSON_SAFE_CLASSES <- c(
+  "logical", "integer", "numeric", "double", "character",
+  "factor", "Date", "POSIXct", "POSIXt", "data.frame", "list"
+)
+
+#' Make a value safe for JSON serialization
 #'
-#' @param x Value to normalize
-#' @return NULL if x is NULL or has length 0, otherwise x
-nz <- function(x) {
-  if (is.null(x) || length(x) == 0) NULL else x
+#' Module outputs can embed values carrying S3 classes jsonlite has no `asJSON`
+#' method for — notably `ellmer_output`, attached by ellmer's structured LLM
+#' extraction to columns inside a module's `table`/`summary_table`. metacheck
+#' keeps these classes for R-side display (DT/`report_table`), but serializing
+#' them aborts the request with "No method asJSON S3 class: ellmer_output".
+#'
+#' This walks the structure and drops any class outside `.JSON_SAFE_CLASSES`
+#' down to its underlying type (e.g. an `ellmer_output` character vector becomes
+#' a plain character vector), recursing into data frames, list columns, and
+#' nested lists. Base types, factors, dates, and data frames pass through
+#' unchanged.
+#'
+#' @param x Any value destined for a JSON response
+#' @return The same value with unserializable S3 classes stripped
+json_safe <- function(x) {
+  if (is.data.frame(x)) {
+    x[] <- lapply(x, json_safe)
+    return(x)
+  }
+  if (length(setdiff(class(x), .JSON_SAFE_CLASSES))) {
+    x <- unclass(x)
+    if (!is.null(attr(x, "class"))) x <- as.character(x)
+  }
+  if (is.list(x)) x <- lapply(x, json_safe)
+  x
 }
 
 #' Extract uploaded file path from multipart form data
@@ -44,30 +73,171 @@ error_response <- function(res, status, message) {
 }
 
 
-#' Read a paper from GROBID XML file
+#' Parse a multipart string parameter into a logical
 #'
-#' @param file_path Path to GROBID XML file
+#' Multipart form fields arrive as strings; this accepts the usual truthy/falsy
+#' spellings ("true"/"false"/"1"/"0"/"yes"/"no", any case) and returns
+#' `default` when the value is absent or unrecognised. (Base `as.logical()`
+#' returns NA for "0"/"1"/"yes"/"no", which is why we don't lean on it here.)
+#'
+#' @param x the raw parameter value (character or NULL)
+#' @param default logical to return when `x` is missing or unparseable
+#' @return a single logical
+parse_bool <- function(x, default = TRUE) {
+  if (is.null(x) || length(x) == 0 || !nzchar(x[1])) return(default)
+  v <- tolower(trimws(as.character(x)[1]))
+  if (v %in% c("true", "t", "1", "yes", "y")) return(TRUE)
+  if (v %in% c("false", "f", "0", "no", "n")) return(FALSE)
+  default
+}
+
+
+#' Extract named info fields from a paper object
+#'
+#' Replacement for the removed package-level `info_table()`. Uses
+#' `paper_table(paper, "info")` to get all info fields, then subsets to the
+#' requested `fields`, tolerating any that are absent in the data.
+#'
+#' @param paper a paper object (scivrs_paper)
+#' @param fields character vector of field names to return
+#' @return a one-row tibble with paper_id plus the requested fields (NA for
+#'   missing fields)
+info_fields <- function(paper, fields) {
+  tbl <- paper_table(paper, "info")
+
+  # Add any requested columns that are absent in the table (e.g. "submission",
+  # "received", "accepted" are not present in every bibr output)
+  missing_cols <- setdiff(fields, names(tbl))
+  for (col in missing_cols) {
+    tbl[[col]] <- NA_character_
+  }
+
+  # Always prepend paper_id; then keep only requested fields
+  keep <- intersect(c("paper_id", fields), names(tbl))
+  tbl[, keep, drop = FALSE]
+}
+
+
+#' Read a paper from a bibr JSON file
+#'
+#' @param file_path Path to bibr JSON file
 #' @param request_id Request ID for logging
 #' @return List with success status and either paper object or error message
 read_paper <- function(file_path, request_id) {
   logger::log_info("Reading paper: {request_id}")
 
-  # Read paper with error handling
+  # .read_bibr directly, NOT read(): read() swallows per-file errors into
+  # NULL, after which paperlist() throws a misleading error and print()s the
+  # parsed structure into the logs. The internal reader surfaces the real
+  # parse error so error_response() can return it to the client.
   result <- tryCatch(
     {
-      logger::log_info("Reading GROBID XML file")
-      metacheck::read_grobid(file_path)
+      logger::log_info("Reading bibr JSON file")
+      metacheck:::.read_bibr(file_path)
     },
     error = function(e) {
-      logger::log_error("Error reading paper: {e$message}")
+      logger::log_error("Error reading paper: {conditionMessage(e)}")
       e
     }
   )
 
   if (inherits(result, "error")) {
-    return(list(success = FALSE, error = result$message))
+    return(list(success = FALSE, error = conditionMessage(result)))
   }
 
   logger::log_info("Paper read successfully: {request_id}")
   list(success = TRUE, paper = result)
+}
+
+
+#' Run an endpoint handler against an uploaded, parsed paper
+#'
+#' Centralises the pipeline every paper endpoint used to repeat by hand: a
+#' request id (+ start log), multipart parse, file extraction, upload
+#' validation, and the bibr parse — returning the right `error_response()` at
+#' each failure point.
+#'
+#' The upload is read straight from the tempfile `mime::parse_multipart()`
+#' already wrote — no second copy (that doubled I/O on payloads up to the 50MB
+#' cap) — and is `unlink()`ed when the request returns, so parsed uploads don't
+#' accumulate in the session tempdir.
+#'
+#' `prevalidate` (optional) runs after the multipart parse but BEFORE the
+#' (expensive) bibr parse, so an endpoint can reject bad parameters without
+#' paying the parse cost. It receives `mp` and returns NULL to proceed, or a
+#' `list(status=, message=)` to abort the request with that error.
+#'
+#' @param req,res plumber request/response objects
+#' @param endpoint short endpoint name, for logging
+#' @param handler function(paper, mp, request_id) producing the response body
+#' @param prevalidate optional function(mp) -> NULL | list(status, message)
+#' @return the handler's value, or an `error_response()` list
+with_uploaded_paper <- function(req, res, endpoint, handler, prevalidate = NULL) {
+  request_id <- uuid::UUIDgenerate()
+  logger::log_info("Request started ({endpoint}): {request_id}")
+
+  mp <- mime::parse_multipart(req)
+  uploaded_file <- extract_uploaded_file(mp)
+  # mime leaves its multipart tempfile(s) in the session tempdir; clean them up
+  # when the request returns (the response body is already in memory by then).
+  on.exit(if (!is.null(uploaded_file)) unlink(uploaded_file), add = TRUE)
+
+  validation <- validate_file_upload(uploaded_file)
+  if (!validation$valid) {
+    return(error_response(res, validation$status, validation$message))
+  }
+
+  if (!is.null(prevalidate)) {
+    pv <- prevalidate(mp)
+    if (!is.null(pv)) return(error_response(res, pv$status, pv$message))
+  }
+
+  paper_obj <- read_paper(uploaded_file, request_id)
+  if (!paper_obj$success) {
+    return(error_response(res, 400, paper_obj$error))
+  }
+
+  handler(paper_obj$paper, mp, request_id)
+}
+
+
+#' Render metacheck's native HTML report from already-run module outputs
+#'
+#' Reuses the module outputs `/check` just computed (NO module re-run, no extra
+#' LLM calls): builds the report qmd with `report_qmd()` and renders it to a
+#' single self-contained HTML file with Quarto. The report template sets
+#' `embed-resources: true`, so the output is one standalone file.
+#'
+#' Best-effort by contract: any failure (Quarto missing, render error, an
+#' unexpected paper/module shape) returns "" so the JSON `/check` response is
+#' never affected. The caller includes whatever this returns as `report_html`.
+#'
+#' @param module_output named list of `metacheck_module_output` objects
+#' @param paper the paper object (`scivrs_paper`)
+#' @param request_id request id, for logging
+#' @return the rendered HTML as a single string, or "" if rendering failed
+render_report_html <- function(module_output, paper, request_id = "") {
+  tryCatch(
+    {
+      report_text <- metacheck::report_qmd(module_output, paper)
+
+      qmd <- tempfile(fileext = ".qmd")
+      html <- sub("\\.qmd$", ".html", qmd)
+      on.exit(unlink(c(qmd, html)), add = TRUE)
+      writeLines(report_text, qmd)
+
+      # quarto writes the .html next to the input .qmd (both in tempdir)
+      quarto::quarto_render(input = qmd, output_format = "html", quiet = TRUE)
+
+      if (!file.exists(html)) {
+        logger::log_warn("report html not produced ({request_id})")
+        return("")
+      }
+      paste(readLines(html, warn = FALSE), collapse = "\n")
+    },
+    error = function(e) {
+      logger::log_warn("report render failed ({request_id}): {conditionMessage(e)}")
+      ""
+    }
+  )
 }

--- a/inst/plumber/utils/validators.R
+++ b/inst/plumber/utils/validators.R
@@ -1,25 +1,21 @@
 # validators.R
-# Validation functions for plumber API
+# Validation functions for plumber API (bibr JSON input)
 
-#' Check if a file is a valid XML
+# Sized against bibr JSON *output* (text-heavy JSON from a 30MB PDF), not the
+# platform's PDF upload cap. The platform strips base64 figures before
+# POSTing, so real payloads stay in single-digit MB.
+MAX_UPLOAD_BYTES <- 50 * 1024 * 1024
+
+#' Validate file upload (bibr JSON)
 #'
-#' @param file_path Path to the file to check
-#' @return Logical indicating if file is a valid XML
-is_xml_file <- function(file_path) {
-  tryCatch(
-    {
-      xml2::read_xml(file_path)
-      TRUE
-    },
-    error = function(e) FALSE
-  )
-}
-
-#' Validate file upload (XML only)
+#' Cheap structural checks only — JSON validity is established by the single
+#' parse inside read_paper() (parsing a 50MB body twice in a single-threaded
+#' process is a real cost), and parse errors surface through error_response().
 #'
 #' @param file_path Path to the uploaded file
+#' @param max_bytes Maximum allowed file size in bytes
 #' @return List with valid (logical), and optionally status and message
-validate_file_upload <- function(file_path) {
+validate_file_upload <- function(file_path, max_bytes = MAX_UPLOAD_BYTES) {
   if (is.null(file_path)) {
     logger::log_warn("Request rejected: No file uploaded")
     return(list(
@@ -29,7 +25,6 @@ validate_file_upload <- function(file_path) {
     ))
   }
 
-  # Check if multiple files were uploaded
   if (length(file_path) > 1) {
     logger::log_warn("Request rejected: Multiple files uploaded")
     return(list(
@@ -48,26 +43,15 @@ validate_file_upload <- function(file_path) {
     ))
   }
 
-  if (file.size(file_path) > 3 * 1024 * 1024) { # 3MB limit
+  if (file.size(file_path) > max_bytes) {
     logger::log_warn("Request rejected: File too large ({file.size(file_path)} bytes)")
     return(list(
       valid = FALSE,
       status = 413,
-      message = "File too large. Maximum size is 3MB."
+      message = sprintf("File too large. Maximum size is %dMB.", max_bytes %/% (1024 * 1024))
     ))
   }
 
-  is_xml <- is_xml_file(file_path)
-
-  if (!is_xml) {
-    logger::log_warn("Request rejected: Invalid file type (not GROBID XML)")
-    return(list(
-      valid = FALSE,
-      status = 400,
-      message = "Uploaded file is not a valid GROBID XML file."
-    ))
-  }
-
-  logger::log_info("File uploaded: size={file.size(file_path)} bytes, type=XML")
+  logger::log_info("File uploaded: size={file.size(file_path)} bytes, type=JSON")
   list(valid = TRUE)
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1,11 +1,12 @@
 # test-11-api.R
 # Tests for the metacheck Plumber API
 
-# GET test files
-test_xml <- system.file("grobid", "prereg.xml", package = "metacheck")
+# GET test files (bibr JSON — the API no longer accepts GROBID XML)
+test_json <- system.file("demos", "to_err_is_human.json", package = "metacheck")
+golden_json <- system.file("demos", "golden_bibr_10_2.json", package = "metacheck")
 
-# API base URL
-api_url <- "http://localhost:2005"
+# API base URL (override with METACHECK_API_URL to test a non-default instance)
+api_url <- Sys.getenv("METACHECK_API_URL", "http://localhost:2005")
 
 # Helper function to check if API is running
 api_is_running <- function() {
@@ -49,7 +50,7 @@ test_that("/paper/info returns paper info", {
   skip_if_no_api()
 
   resp <- httr2::request(paste0(api_url, "/paper/info")) |>
-    httr2::req_body_multipart(file = curl::form_file(test_xml)) |>
+    httr2::req_body_multipart(file = curl::form_file(test_json)) |>
     httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform()
 
@@ -59,7 +60,7 @@ test_that("/paper/info returns paper info", {
   expect_type(content, "list")
   # Should have some paper metadata
   expect_true(length(content) > 0)
-  expect_equal(content[[1]]$title, "Will knowledge about more efficient study designs increase the willingness to pre-register?")
+  expect_equal(content[[1]]$title, "To Err is Human: An Empirical Investigation")
 })
 
 # Test /paper/authors endpoint
@@ -67,7 +68,7 @@ test_that("/paper/authors returns author table", {
   skip_if_no_api()
 
   resp <- httr2::request(paste0(api_url, "/paper/authors")) |>
-    httr2::req_body_multipart(file = curl::form_file(test_xml)) |>
+    httr2::req_body_multipart(file = curl::form_file(test_json)) |>
     httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform()
 
@@ -75,7 +76,7 @@ test_that("/paper/authors returns author table", {
 
   content <- httr2::resp_body_json(resp)
   expect_type(content, "list")
-  expect_equal(content[[1]]$name.surname, "Lakens")
+  expect_equal(content[[1]]$family, "Lakens")
 })
 
 # Test /paper/references endpoint
@@ -83,7 +84,7 @@ test_that("/paper/references returns references", {
   skip_if_no_api()
 
   resp <- httr2::request(paste0(api_url, "/paper/references")) |>
-    httr2::req_body_multipart(file = curl::form_file(test_xml)) |>
+    httr2::req_body_multipart(file = curl::form_file(test_json)) |>
     httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform()
 
@@ -91,7 +92,7 @@ test_that("/paper/references returns references", {
 
   content <- httr2::resp_body_json(resp)
   expect_type(content, "list")
-  expect_equal(content[[1]]$title, "A brief note on one-tailed tests.")
+  expect_equal(content[[1]]$title, "Faux: Simulation for Factorial Designs")
 })
 
 # Test /paper/cross-references endpoint
@@ -99,7 +100,7 @@ test_that("/paper/cross-references returns cross-references", {
   skip_if_no_api()
 
   resp <- httr2::request(paste0(api_url, "/paper/cross-references")) |>
-    httr2::req_body_multipart(file = curl::form_file(test_xml)) |>
+    httr2::req_body_multipart(file = curl::form_file(test_json)) |>
     httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform()
 
@@ -115,7 +116,7 @@ test_that("/paper/search finds text in paper", {
 
   resp <- httr2::request(paste0(api_url, "/paper/search")) |>
     httr2::req_body_multipart(
-      file = curl::form_file(test_xml),
+      file = curl::form_file(test_json),
       pattern = "pre-register"
     ) |>
     httr2::req_error(is_error = \(resp) FALSE) |>
@@ -132,7 +133,7 @@ test_that("/paper/search requires query parameter", {
   skip_if_no_api()
 
   resp <- httr2::request(paste0(api_url, "/paper/search")) |>
-    httr2::req_body_multipart(file = curl::form_file(test_xml)) |>
+    httr2::req_body_multipart(file = curl::form_file(test_json)) |>
     httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform()
 
@@ -146,7 +147,10 @@ test_that("/paper/search requires query parameter", {
 test_that("Endpoints return 400 when no file is uploaded", {
   skip_if_no_api()
 
+  # Force POST (no body): an empty GET would hit a non-existent route, not the
+  # upload handler's "no file" path.
   resp <- httr2::request(paste0(api_url, "/paper/info")) |>
+    httr2::req_method("POST") |>
     httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform()
 
@@ -156,13 +160,13 @@ test_that("Endpoints return 400 when no file is uploaded", {
   expect_true("error" %in% names(content))
 })
 
-# Test error handling: invalid XML file
-test_that("Endpoints return 400 for invalid XML", {
+# Test error handling: invalid JSON file
+test_that("Endpoints return 400 for non-JSON file", {
   skip_if_no_api()
 
-  # Create a temporary non-XML file
+  # Create a temporary non-JSON file
   tmp_file <- withr::local_tempfile(fileext = ".txt")
-  writeLines("This is not XML", tmp_file)
+  writeLines("This is not JSON", tmp_file)
 
   resp <- httr2::request(paste0(api_url, "/paper/info")) |>
     httr2::req_body_multipart(file = curl::form_file(tmp_file)) |>
@@ -171,6 +175,159 @@ test_that("Endpoints return 400 for invalid XML", {
 
   expect_equal(httr2::resp_status(resp), 400)
 
+  content <- httr2::resp_body_json(resp)
+  expect_true("error" %in% names(content))
+})
+
+# Current bibr (10.2) golden file parses and checks
+test_that("/paper/info handles a 10.2-shaped bibr JSON", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/info")) |>
+    httr2::req_body_multipart(file = curl::form_file(golden_json)) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 200)
+})
+
+# Malformed JSON is a client error with the real parse message
+test_that("/paper/info rejects malformed JSON with 400", {
+  skip_if_no_api()
+
+  bad <- withr::local_tempfile(fileext = ".json")
+  writeLines("this is not json {", bad)
+
+  resp <- httr2::request(paste0(api_url, "/paper/info")) |>
+    httr2::req_body_multipart(file = curl::form_file(bad)) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 400)
+  content <- httr2::resp_body_json(resp)
+  expect_true("error" %in% names(content))
+})
+
+# A cheap, non-LLM, network-free module used by the /module and /check tests.
+cheap_module <- "all_urls"
+
+# Test /paper/modules discovery endpoint
+test_that("/paper/modules lists the available modules", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/modules")) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 200)
+
+  content <- httr2::resp_body_json(resp)
+  expect_true("modules" %in% names(content))
+  expect_true(length(content$modules) > 0)
+  expect_true(cheap_module %in% unlist(content$modules))
+})
+
+# Test /paper/module runs a module
+test_that("/paper/module runs a module and returns results", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/module")) |>
+    httr2::req_body_multipart(
+      file = curl::form_file(test_json),
+      name = cheap_module
+    ) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 200)
+  content <- httr2::resp_body_json(resp)
+  expect_type(content, "list")
+})
+
+# Test /paper/module rejects an unknown module name
+test_that("/paper/module rejects an unknown module with 400", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/module")) |>
+    httr2::req_body_multipart(
+      file = curl::form_file(test_json),
+      name = "no_such_module"
+    ) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 400)
+  content <- httr2::resp_body_json(resp)
+  expect_true("error" %in% names(content))
+})
+
+# Test /paper/module requires the name parameter
+test_that("/paper/module requires a module name", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/module")) |>
+    httr2::req_body_multipart(file = curl::form_file(test_json)) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 400)
+})
+
+# Test /paper/check aggregates metadata + module results; report=false skips render
+test_that("/paper/check returns metadata and module results (report=false)", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/check")) |>
+    httr2::req_body_multipart(
+      file = curl::form_file(test_json),
+      modules = cheap_module,
+      report = "false"
+    ) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 200)
+  content <- httr2::resp_body_json(resp)
+  expect_true(all(c(
+    "metacheck_version", "paper_info", "authors", "references",
+    "cross_references", "modules_run", "results", "report_html"
+  ) %in% names(content)))
+  # report=false -> empty report_html, but JSON results are still present
+  expect_equal(as.character(content$report_html), "")
+  expect_true(length(content$results) > 0)
+})
+
+# Test /paper/check renders the HTML report by default
+test_that("/paper/check renders an HTML report by default", {
+  skip_if_no_api()
+  skip_if_not(nzchar(Sys.which("quarto")), "quarto CLI not available")
+
+  resp <- httr2::request(paste0(api_url, "/paper/check")) |>
+    httr2::req_body_multipart(
+      file = curl::form_file(test_json),
+      modules = cheap_module
+    ) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 200)
+  content <- httr2::resp_body_json(resp)
+  expect_true(nchar(as.character(content$report_html)) > 0)
+})
+
+# Test /paper/check rejects invalid module names before parsing
+test_that("/paper/check rejects invalid module names with 400", {
+  skip_if_no_api()
+
+  resp <- httr2::request(paste0(api_url, "/paper/check")) |>
+    httr2::req_body_multipart(
+      file = curl::form_file(test_json),
+      modules = "no_such_module"
+    ) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
+    httr2::req_perform()
+
+  expect_equal(httr2::resp_status(resp), 400)
   content <- httr2::resp_body_json(resp)
   expect_true("error" %in% names(content))
 })

--- a/tests/testthat/test-plumber-helpers.R
+++ b/tests/testthat/test-plumber-helpers.R
@@ -1,0 +1,129 @@
+# Unit tests for plumber response helpers.
+# Sources helpers.R directly — no running API needed.
+
+source(testthat::test_path("..", "..", "inst", "plumber", "utils", "helpers.R"))
+
+# Regression: LLM modules embed `ellmer_output`-classed values (from ellmer's
+# structured extraction) in their table columns. jsonlite has no asJSON method
+# for that class, so serializing a /check or /module response aborted the whole
+# request with "No method asJSON S3 class: ellmer_output". json_safe() must
+# strip such classes to plain, serializable values.
+
+ellmer_table <- function() {
+  t <- data.frame(claim = c("c1", "c2"), stringsAsFactors = FALSE)
+  t$apriori <- structure(c('{"apriori": false}', '{"apriori": true}'),
+                         class = "ellmer_output")
+  t
+}
+
+test_that("raw ellmer_output column is unserializable (the bug)", {
+  expect_error(
+    jsonlite::toJSON(ellmer_table(), auto_unbox = TRUE),
+    "asJSON"
+  )
+})
+
+test_that("json_safe strips ellmer_output so the table serializes", {
+  safe <- json_safe(ellmer_table())
+  expect_silent(out <- jsonlite::toJSON(safe, auto_unbox = TRUE))
+  # underlying JSON-string values are preserved, just declassed
+  expect_false(inherits(safe$apriori, "ellmer_output"))
+  expect_equal(safe$apriori, c('{"apriori": false}', '{"apriori": true}'))
+})
+
+test_that("json_safe handles a list-column of per-row ellmer_output", {
+  t <- data.frame(x = 1:2)
+  t$llm <- I(list(structure("a", class = "ellmer_output"),
+                  structure("b", class = "ellmer_output")))
+  safe <- json_safe(list(module = "m", summary_table = t))
+  expect_silent(jsonlite::toJSON(safe, auto_unbox = TRUE))
+})
+
+test_that("json_safe sanitizes nested module-output lists", {
+  obj <- structure(
+    list(module = "causal_claims", table = ellmer_table(),
+         section = "general", traffic_light = "info"),
+    class = "metacheck_module_output"
+  )
+  expect_silent(jsonlite::toJSON(json_safe(obj), auto_unbox = TRUE))
+})
+
+test_that("json_safe leaves ordinary columns untouched", {
+  t <- data.frame(
+    n = 1:2,
+    f = factor(c("a", "b")),
+    d = as.Date(c("2026-01-01", "2026-01-02"))
+  )
+  safe <- json_safe(t)
+  expect_equal(safe$n, 1:2)
+  expect_s3_class(safe$d, "Date")
+  expect_s3_class(safe$f, "factor")
+  expect_silent(jsonlite::toJSON(safe, auto_unbox = TRUE))
+})
+
+# --- parse_bool -------------------------------------------------------------
+
+test_that("parse_bool reads truthy/falsy spellings and falls back to default", {
+  for (v in c("true", "TRUE", "True", "1", "yes", "y", "t")) expect_true(parse_bool(v))
+  for (v in c("false", "FALSE", "False", "0", "no", "n", "f")) expect_false(parse_bool(v))
+  # absent / blank -> default
+  expect_true(parse_bool(NULL))
+  expect_true(parse_bool(""))
+  expect_true(parse_bool(character(0)))
+  expect_false(parse_bool(NULL, default = FALSE))
+  # unrecognised -> default (honours the supplied default)
+  expect_true(parse_bool("maybe"))
+  expect_false(parse_bool("maybe", default = FALSE))
+})
+
+# --- endpoint logic without a running API (runs in CI) ----------------------
+# These exercise the real /check + /module paths — module run -> json_safe ->
+# JSON serialization, and the HTML report render — without an HTTP server, so
+# the headline endpoints are covered even where the API integration tests skip.
+# A cheap, non-LLM, network-free module keeps them fast and deterministic.
+CHEAP_MODULE <- "all_urls"
+
+test_that("info_fields returns paper_id plus requested fields, tolerating absent ones", {
+  skip_if_not(exists("demopaper"), "metacheck not loaded")
+  paper <- demopaper()
+  out <- info_fields(paper, c("title", "doi", "definitely_absent_field"))
+  expect_s3_class(out, "data.frame")
+  expect_equal(nrow(out), 1L)
+  expect_true("paper_id" %in% names(out))
+  expect_true(all(c("title", "definitely_absent_field") %in% names(out)))
+  expect_true(is.na(out$definitely_absent_field)) # absent field -> NA
+})
+
+test_that("the /check module pipeline yields a JSON-serializable result", {
+  skip_if_not(exists("demopaper"), "metacheck not loaded")
+  paper <- demopaper()
+  mo <- module_run(paper, CHEAP_MODULE)
+  # The exact JSON-safe view /check builds for each module.
+  view <- json_safe(list(
+    module = mo$module, title = mo$title, table = mo$table,
+    summary_table = mo$summary_table, summary_text = mo$summary_text,
+    report = mo$report, traffic_light = mo$traffic_light
+  ))
+  expect_silent(jsonlite::toJSON(view, auto_unbox = TRUE))
+})
+
+test_that("render_report_html renders HTML from real module outputs", {
+  skip_if_not(exists("demopaper"), "metacheck not loaded")
+  skip_if_not(nzchar(Sys.which("quarto")), "quarto CLI not available")
+  paper <- demopaper()
+  mo <- module_run(paper, CHEAP_MODULE)
+  html <- render_report_html(stats::setNames(list(mo), CHEAP_MODULE), paper, "test")
+  expect_type(html, "character")
+  expect_length(html, 1L)
+  expect_match(html, "<html|<!DOCTYPE", ignore.case = TRUE)
+})
+
+test_that("render_report_html degrades gracefully (never throws, one string)", {
+  # Best-effort contract: any failure returns "" rather than erroring, so the
+  # JSON /check response is never sunk by a bad render.
+  out <- tryCatch(render_report_html(list(), list(), "test"),
+                  error = function(e) e)
+  expect_false(inherits(out, "error"))
+  expect_type(out, "character")
+  expect_length(out, 1L)
+})

--- a/tests/testthat/test-plumber-validators.R
+++ b/tests/testthat/test-plumber-validators.R
@@ -1,0 +1,41 @@
+# Unit tests for plumber upload validation.
+# Sources validators.R directly — no running API needed.
+
+source(testthat::test_path("..", "..", "inst", "plumber", "utils", "validators.R"))
+
+test_that("rejects missing file", {
+  v <- validate_file_upload(NULL)
+  expect_false(v$valid)
+  expect_equal(v$status, 400)
+})
+
+test_that("rejects multiple files", {
+  v <- validate_file_upload(c("a.json", "b.json"))
+  expect_false(v$valid)
+  expect_equal(v$status, 400)
+})
+
+test_that("rejects nonexistent file", {
+  v <- validate_file_upload(tempfile(fileext = ".json"))
+  expect_false(v$valid)
+  expect_equal(v$status, 400)
+})
+
+test_that("accepts an existing file under the size cap", {
+  f <- tempfile(fileext = ".json")
+  writeLines('{"paper_id": "x"}', f)
+  v <- validate_file_upload(f)
+  expect_true(v$valid)
+})
+
+test_that("rejects files over the size cap", {
+  f <- tempfile(fileext = ".json")
+  writeLines('{"paper_id": "x"}', f)
+  v <- validate_file_upload(f, max_bytes = 5)
+  expect_false(v$valid)
+  expect_equal(v$status, 413)
+})
+
+test_that("default cap is 50MB", {
+  expect_equal(MAX_UPLOAD_BYTES, 50 * 1024 * 1024)
+})


### PR DESCRIPTION
Standalone extraction from #329 (splitting the large Fable-audit PR into small, per-concern PRs). This is the coherent **Plumber feature** thread — needed for next week's deploy.

## What's in it
- **Ingestion:** validate uploads as bibr JSON; raise size cap to 50MB; read via `metacheck:::.read_bibr` directly (surfaces per-file errors that `read()` swallows).
- **/check:** includes `metacheck_version`; renders metacheck's HTML report (`report_html`); `report=false` to skip rendering.
- **Endpoints:** DRY'd request pipeline; new `/modules` endpoint; strip unserializable S3 classes before JSON serialization.
- **Runtime:** hardened Dockerfile + docker-compose; expanded README.
- **Tests:** `test-api.R` (expanded), new `test-plumber-helpers.R`, new `test-plumber-validators.R`.

## Scope / independence
Contains only `inst/plumber/*`, the three plumber test files, and the golden fixture the tests load (`inst/demos/golden_bibr_10_2.json`). It reads bibr via `.read_bibr` directly, so it does **not** depend on the `read()` passthrough (#332) or on the schema sync (#330).

## Verification
Ran the plumber suite in isolation on the `dev` base: **96 passed, 0 failed**. (The `.paper_schema` drift that's red on `dev` until #330 lands is in `test-paper.R`, not exercised here.)

https://claude.ai/code/session_01YLqyRiqzyaZncJ3m5VcjxK