### PR TITLE
fix(llm): correct ollama-native gate (&& not %%); fail-fast param/model checks

### DIFF
--- a/R/llm.R
+++ b/R/llm.R
@@ -71,11 +71,25 @@ llm <- function(text, system_prompt,
   # check if json schema type is set for a structured return
   structured <- !is.null(type)
 
+  # check params early: catches typos/bad values before any provider or
+  # network work (the raw `params` list is still needed for the ollama path,
+  # so only the converted copy is kept for the ellmer chat below)
+  tryCatch({
+    checked_params <- do.call(ellmer::params, params)
+  }, error = \(e) {
+    stop("Misspecified params argument:\n", e$message, call. = FALSE)
+  })
+
+  if (is.null(model) || length(model) == 0 || !nzchar(model[[1]])) {
+    stop("No LLM model is set; pass `model` or set a default with llm_model()",
+         call. = FALSE)
+  }
+
   # ollama checks ----
   use_ollama_native <- FALSE
   if (grepl("^ollama", model)) {
     # ollama's /v1/ endpoint ignores think=FALSE; native /api/chat honours it
-    use_ollama_native <- !isTRUE(params$think) %% !structured
+    use_ollama_native <- !isTRUE(params$think) && !structured
     if (use_ollama_native) {
       ollama_options <- params
       ollama_options$think <- NULL
@@ -107,12 +121,8 @@ llm <- function(text, system_prompt,
     }
   }
 
-  # check params ----
-  tryCatch({
-    params <- do.call(ellmer::params, params)
-  }, error = \(e) {
-    stop("Misspecified params argument:\n", e$message, call. = FALSE)
-  })
+  # params were validated above, before the provider checks
+  params <- checked_params
 
   # set up progress bar ----
   label <- if (structured) "Extracting data" else "Querying LLM"
@@ -420,10 +430,12 @@ llm_max_calls <- function(n = NULL) {
 #' @return NULL
 #' @export
 #'
-llm_model <- function(model = NULL) {
-  if (is.null(model)) {
+llm_model <- function(model) {
+  # missing() rather than a NULL default so llm_model(NULL) can RESET the
+  # option (restoring a saved value that happened to be NULL round-trips)
+  if (missing(model)) {
     return(getOption("metacheck.llm.model"))
-  } else if (is.character(model)) {
+  } else if (is.null(model) || is.character(model)) {
     options(metacheck.llm.model = model)
     invisible(getOption("metacheck.llm.model"))
   } else {

--- a/man/llm_model.Rd
+++ b/man/llm_model.Rd
@@ -4,7 +4,7 @@
 \alias{llm_model}
 \title{Set the default LLM model}
 \usage{
-llm_model(model = NULL)
+llm_model(model)
 }
 \arguments{
 \item{model}{the name of the model}


### PR DESCRIPTION
Standalone extraction from #329 — the genuine logic bug flagged for fast-tracking.

## The bug
`llm()`'s ollama-native gate read:
```r
use_ollama_native <- !isTRUE(params$think) %% !structured   # %% is modulo!
```
`%%` is the modulo operator, so `use_ollama_native` was computed by arithmetic on logicals (`TRUE %% TRUE` → `0`, `TRUE %% FALSE` → `NaN`) instead of the intended boolean AND. Fixed to `&&`.

## Also in this file (same function / same exported helper)
- **Fail-fast validation:** check `params` and that a model is set *before* any provider or network work, with clear errors, instead of failing deep in the call.
- **`llm_model()` reset:** switch to `missing()` semantics so `llm_model(NULL)` can reset the option (a saved `NULL` round-trips). `man/llm_model.Rd` regenerated to match.

## Verification (on the `dev` base)
`test-llm.R` and the `utils`/`svutils` suites pass. The only red is `test-utils.R::.onLoad` (2 expectations) — **pre-existing on `dev`**, not caused by this change: I ran it on a clean `origin/dev` worktree and it fails identically. Cause: `.onLoad` derives `metacheck.llm.model` from configured API keys, but the current dev test hardcodes `"groq"`, so it fails in any environment without `GROQ_API_KEY`. That's fixed by the held `test-utils.R` change (parked with the other test-infra cleanup); happy to send it as a follow-up.

https://claude.ai/code/session_01YLqyRiqzyaZncJ3m5VcjxK