### PR TITLE
Module fixes: effect-size crash on empty results, table-only limitation docs, report pagination

### DIFF
--- a/inst/modules/all_p_values.R
+++ b/inst/modules/all_p_values.R
@@ -8,6 +8,8 @@
 #'
 #' This will catch most comparators like =<>~≈≠≤≥≪≫ and most versions of scientific notation like 5.0 x 10^-2 or 5.0e-2. If you find any formats that are not correctly handled by this function, please contact the author.
 #'
+#' This module only checks p-values reported in the running text of the manuscript. It cannot (yet) process p-values reported only in tables.
+#'
 #' @keywords results
 #'
 #' @author Lisa DeBruine (\email{lisa.debruine@glasgow.ac.uk})

--- a/inst/modules/coi_check_oi.R
+++ b/inst/modules/coi_check_oi.R
@@ -1,4 +1,4 @@
-#' COI Check (Overinclusive)
+#' COI Check Overinclusive
 #'
 #' @description
 #' Identify and extract Conflicts of Interest (COI) statements.

--- a/inst/modules/ref_pubpeer.R
+++ b/inst/modules/ref_pubpeer.R
@@ -79,7 +79,7 @@ ref_pubpeer <- function(paper) {
     names(report_table) <- c("Reference", "Comments", "PubPeer Link")
 
     ## report ----
-    report <- c(report_text, scroll_table(report_table))
+    report <- c(report_text, scroll_table(report_table, maxrows = 10))
   }
 
   # return a list ----

--- a/inst/modules/stat_check.R
+++ b/inst/modules/stat_check.R
@@ -10,6 +10,8 @@
 #'
 #' Statcheck considers p = 0.000 an error, as you should report p < 0.001. Furthermore, p < 0.03 is an error if the p-value was 0.031, and one should simply report exact p-values (p = 0.031). Statcheck might miss one-sided tests, and falsely assume the p-value is incorrect. For more information, see [StatCheck](https://statcheck.io/).
 #'
+#' This module only checks statistical results reported in the running text of the manuscript. It cannot (yet) process statistics reported only in tables.
+#'
 #' <validation>In a sample of 685 tests with 34 instances of inconsistent reporting, Statcheck correctly detected 34 of them, and incorrectly identified 26. Therefore 0% of true instances were missed, and 43% of detections were false positives. See <https://osf.io/preprints/psyarxiv/tcxaj_v1/> for more details of the validation.</validation>
 #'
 #'

--- a/inst/modules/stat_effect_size.R
+++ b/inst/modules/stat_effect_size.R
@@ -6,6 +6,8 @@
 #' @details
 #' The Effect Size check searches for regular expressions that match typical ways in which effect sizes are reported. It subsequently checks different ways in which Cohen's d, g, ηp2, and ωp2 can be computed against the reported value. If effects are missing, or might be incorrect, you the module provides a warning. The module was validated on APA reported statistical tests, and might miss effect sizes that were reported in other reporting styles. It was validated by the Metacheck team on papers published in Psychological Science.
 #'
+#' This module only checks statistical results reported in the running text of the manuscript. It cannot (yet) process statistics reported only in tables.
+#'
 #' <validation>In a sample of 161 papers with 1469 tests, this module correctly detected 1106 reported effect sizes (true positives) and correctly identified 295 cases where no effect size was present (true negatives). However, it missed 23 that were reported (false negatives), and incorrectly identified 45 effect sizes when none were reported (false positives). Among all instances detected by the module, 96% were true cases (positive predictive value). In a validation against 221 reported Cohen's d effect sizes, it correctly indicated coherence in 218 cases (99%). In a validation against 485 partial eta-squared effect sizes, it correctly indicated coherence in 480 (99%) </validation>
 #'
 #' @keywords results
@@ -523,13 +525,21 @@ stat_effect_size <- function(paper) {
     # then restore the original paper/sentence order, which extract_eq() and
     # split() would otherwise reorder by paper_id.
     paper_order <- unique(text_tbl$paper_id)
-    table <- eq |>
+    built <- eq |>
       split(~ paper_id + text_id, drop = TRUE) |>
       lapply(build_rows) |>
-      dplyr::bind_rows() |>
-      dplyr::left_join(text_tbl, by = c("paper_id", "text_id"))
-    table <- table[order(match(table$paper_id, paper_order), table$text_id), , drop = FALSE]
-    rownames(table) <- NULL
+      dplyr::bind_rows()
+    # build_rows() returns NULL for a sentence with effect sizes but no t/F
+    # test; when every sentence is NULL, bind_rows() yields a 0-column frame
+    # with no join keys, so guard the join (and skip to the empty-table return
+    # below) instead of erroring in left_join().
+    if (nrow(built) == 0 || !all(c("paper_id", "text_id") %in% names(built))) {
+      table <- data.frame()
+    } else {
+      table <- dplyr::left_join(built, text_tbl, by = c("paper_id", "text_id"))
+      table <- table[order(match(table$paper_id, paper_order), table$text_id), , drop = FALSE]
+      rownames(table) <- NULL
+    }
   }
 
 

--- a/inst/modules/stat_p_exact.R
+++ b/inst/modules/stat_p_exact.R
@@ -8,6 +8,8 @@
 #'
 #' We try to exclude figure and table notes like "* p < .05", but may not succeed at excluding all false positives.
 #'
+#' This module only checks p-values reported in the running text of the manuscript. It cannot (yet) process p-values reported only in tables (as opposed to a table's footnote text, which the module does see and tries to exclude — see above).
+#'
 #' <validation>In a sample of 225 papers containing 405 instances of non-exact p-values, the module correctly detected 269 cases (true positives) and incorrectly identified 78 (false positives). It missed 136 instances of imprecisely reported p-values (false negatives) and correctly identified 4557 cases of precisely reported p-values (true negative). Additionally, 78% of positive detections were correct (positive predictive value).</validation>
 #'
 #'

--- a/inst/modules/stat_p_nonsig.R
+++ b/inst/modules/stat_p_nonsig.R
@@ -8,6 +8,8 @@
 #'
 #' In the future, the Metacheck team aims to incorporate a machine learning classifier to only return sentences likely to contain misinterpretations. If you want to help to improve the module, reach out to the Metacheck development team.
 #'
+#' This module only checks p-values reported in the running text of the manuscript. It cannot (yet) process p-values reported only in tables.
+#'
 #' <validation>In a sample of 194 papers with 1602 instances of non-significant p-values, this module correctly detected 1486 of them, and incorrectly identified 153. Additionally, 91% of detections were true instances (positive predictive value). That is, when this module flags non-significant p-values in a paper, it correctly identifies an issue 91% of the time.</validation>
 #'
 #'
@@ -16,8 +18,9 @@
 #' @author Daniel Lakens (\email{D.Lakens@tue.nl})
 #'
 #' @references
-#' # Appelbaum, M., Cooper, H., Kline, R. B., Mayo-Wilson, E., Nezu, A. M., & Rao, S. M. (2018). Journal article reporting standards for quantitative research in psychology: The APA Publications and Communications Board task force report. American Psychologist, 73(1), 3–25. https://doi.org/10.1037/amp0000191
-#' # Murphy, S. L., Merz, R., Reimann, L.-E., & Fernández, A. (2025). Nonsignificance misinterpreted as an effect’s absence in psychology: Prevalence and temporal analyses. Royal Society Open Science, 12(3), 242167. https://doi.org/10.1098/rsos.242167
+#' Appelbaum, M., Cooper, H., Kline, R. B., Mayo-Wilson, E., Nezu, A. M., & Rao, S. M. (2018). Journal article reporting standards for quantitative research in psychology: The APA Publications and Communications Board task force report. American Psychologist, 73(1), 3–25. https://doi.org/10.1037/amp0000191
+#'
+#' Murphy, S. L., Merz, R., Reimann, L.-E., & Fernández, A. (2025). Nonsignificance misinterpreted as an effect’s absence in psychology: Prevalence and temporal analyses. Royal Society Open Science, 12(3), 242167. https://doi.org/10.1098/rsos.242167
 #'
 #' @import dplyr
 #'
@@ -85,7 +88,7 @@ stat_p_nonsig <- function(paper) {
     # report text
     report <- c(
       explanation,
-      scroll_table(report_table, colwidths = c(.1, .9)),
+      scroll_table(report_table, colwidths = c(.1, .9), maxrows = 10),
       collapse_section(guidance)
     ) |> paste(collapse = "\n\n")
   }


### PR DESCRIPTION
## Summary

Small, independent fixes across seven check modules. No dependency on any other open PR.

### Bug fix
**`stat_effect_size()` crashed on a paper with no matching results.** `build_rows()` returns `NULL` for a sentence that has effect sizes but no t/F test. When *every* sentence returns `NULL`, `bind_rows()` yields a 0-column frame with no join keys, and the following `left_join()` errored rather than producing an empty result. Now guarded, so the module returns its normal empty table.

### Documentation
`all_p_values`, `stat_check`, `stat_p_exact`, `stat_p_nonsig`, and `stat_effect_size` now state that they only check results reported in the **running text** and cannot yet process statistics reported only in tables. `stat_p_exact` additionally distinguishes a table's *footnote* text (which the module does see, and tries to exclude) from the table *body* (which it cannot read at all) — a distinction that previously wasn't clear from the existing "we try to exclude figure and table notes" wording.

### Report output
`ref_pubpeer` and `stat_p_nonsig` now paginate their report tables at 10 rows (`scroll_table(maxrows = 10)`) instead of the 2-row default, which is too small for these modules' typical result counts.

### Minor
- `coi_check_oi`'s title no longer uses parentheses.
- `stat_p_nonsig`'s two references are now real roxygen references — they were commented out with a stray `#` and so never rendered.

## Test plan
- [ ] `devtools::test(filter = "module-stat")` and `devtools::test(filter = "module-ref")`
- [ ] Note: the `stat_effect_size` crash fix has **no test coverage** — `test-module-stat.R` does not currently exercise `stat_effect_size` at all. Worth adding a regression test for the empty-result case.