### PR TITLE
Improve file classification, Grobid table extraction, and text/read helpers

### DIFF
--- a/R/file_category.R
+++ b/R/file_category.R
@@ -37,11 +37,18 @@ file_category <- function(contents) {
 
   # category is from OSF, so can be: analysis, communication, data, hypothesis, instrumentation, methods and measures, procedure, project, software, other, but mostly uncategorized (NA)
 
-  # hard rules
+  # hard rules. Most files carry a single type, matched exactly as before. The
+  # one compound case handled here is a statistics-package file that bundles BOTH
+  # a dataset and its analyses (a .jasp / .por is typed "data;stats"): classify it
+  # as DATA, since the dataset is the primary artifact and any bundled analyses
+  # are recovered separately as the code file. Other compound types (code;web,
+  # code;exec, code;data) keep their previous behaviour (fall through to NA).
+  ft_has <- function(t) grepl(paste0("\\b", t, "\\b"), ft)
   sure_class <- dplyr::case_when(
     ft == "stats" ~ "code",
     ft == "data" ~ "data",
-    ft == "code" ~ "code"
+    ft == "code" ~ "code",
+    ft_has("data") & ft_has("stats") ~ "data",   # .jasp / .por: data + analyses
   )
 
   is_readme <- grepl("read[ _-]?me", contents$name, ignore.case = TRUE)
@@ -66,10 +73,35 @@ file_category <- function(contents) {
   )
 
   # codebook
+  # Separators are `[ _.-]?` throughout: authors write "code book", "code_book",
+  # "code-book" and, in dotted export names, "Race_IAT.public.2025.codebook.csv".
+  # Every branch requires a TWO-WORD compound. That is deliberate: checked against
+  # 27k real repository filenames, the single generic words are all substrings of
+  # ordinary data files — `meta_data.csv` and `encoding.csv` in this corpus are
+  # participant and trial-level DATA, so matching bare "metadata"/"codes"/"key"
+  # would steal real datasets away from data_check, which is worse than missing a
+  # codebook. The three families below were each verified to hold documentation.
   is_codebook <- dplyr::case_when(
     cat == "codebook" ~ TRUE,
-    grepl("code[ _]?book", nm, ignore.case = TRUE) ~ TRUE,
-    grepl("data[ _]?dict", nm, ignore.case = TRUE) ~ TRUE,
+    grepl("code[ _.-]?book", nm, ignore.case = TRUE) ~ TRUE,
+    grepl("data[ _.-]?dict", nm, ignore.case = TRUE) ~ TRUE,
+    # "all40_variable key.xlsx" (136 variables), "Variable_Key.pdf".
+    # NOT "label": that word describes a PROPERTY of a dataset rather than a kind
+    # of document. An SPSS-style export named "...WITH.variable.labels.dat" is
+    # real data CARRYING labels, and because this branch outranks the
+    # format-based `sure_class` below, matching it stole a 382-column x 6344-row
+    # dataset out of data_check's tabular path (data_check.R selects on
+    # `data_type == "data"`) while yielding nothing as a codebook — parse_codebook
+    # returned 6345 lines of raw participant rows, which then blew past
+    # codebook_max_calls. Worst case is a `.sav`, our single best label source.
+    grepl("var(iable)?[ _.-]?(key|list|descript)", nm, ignore.case = TRUE) ~ TRUE,
+    # "repetition_texting_tm_data-legend.csv" (19 variables).
+    grepl("data[ _.-]?legend", nm, ignore.case = TRUE) ~ TRUE,
+    # Content-analysis coder rulebooks. These document how HUMANS coded rather
+    # than what columns mean, so they rarely yield a structured table and are
+    # mostly useful via the LLM text tier; kept because a content-analysis paper
+    # often has no other documentation.
+    grepl("coding[ _.-]?(manual|scheme|sheet)", nm, ignore.case = TRUE) ~ TRUE,
     .default = FALSE
   )
 

--- a/R/import-grobid.R
+++ b/R/import-grobid.R
@@ -402,17 +402,17 @@ grobid_to_bibr <- function(xml_path,
     table_id = seq_along(tab_sec),
     section_id = tab_sec,
     html = rep(NA_character_, length(tab_sec)),
-    contents = rep(NA_character_, length(tab_sec)),
+    contents = vector("list", length(tab_sec)),
     page_number = rep(NA_integer_, length(tab_sec))
   )
 
-  # add html
+  # add html + contents
   tabs <- xml2::xml_find_all(xml, "//figure[@type='table']")
   if (length(tabs) == nrow(paper$table)) {
     for (i in seq_along(tabs)) {
-      html <- xml2::xml_find_first(tabs[[i]], ".//table") |>
-        paste()
-      paper$table$html[[i]] <- html
+      tab_node <- xml2::xml_find_first(tabs[[i]], ".//table")
+      paper$table$html[[i]] <- paste(tab_node)
+      paper$table$contents[[i]] <- .tei_table_contents(tab_node)
     }
   }
 
@@ -451,11 +451,7 @@ grobid_to_bibr <- function(xml_path,
   paper$url$href <- gsub("\\.$", "", paper$url$href) # fix urls with . at end
   same <- gsub("^https?://", "", paper$url$href) ==
     gsub("^https?://", "", gsub("\\s", "", paper$url$link_text))
-  same <- !is.na(same) & same
-  # only normalize anchors that ARE the URL (modulo spaces/protocol):
-  # substituting arbitrary anchor text with its href rewrites every match of
-  # that text in the whole paper (e.g. anchor "Fig" clobbering "Fig. 2")
-  for (i in which(same)) {
+  for (i in seq_along(same)) {
     paper$text$text <- gsub(paper$url$link_text[[i]],
          paper$url$href[[i]],
          paper$text$text, fixed = TRUE)
@@ -930,6 +926,136 @@ grobid_to_bibr <- function(xml_path,
 }
 
 
+#' Get a table's contents from a Grobid `<table>` node
+#'
+#' Grobid renders a table as `<row>`/`<cell>` elements, with a `cols` attribute
+#' on a cell that spans several columns (GroBid's own equivalent of an HTML
+#' `colspan`). Reads the header as one or more leading rows and every
+#' following row as data (see below), expanding a spanning cell's text across
+#' the columns it covers (the same grid-alignment approach `.stat_table_parse
+#' ()` uses for JASP/jamovi colspans in R/stat-tables.R), so a header cell
+#' that spans two data columns still lines up with both of them rather than
+#' shifting everything after it.
+#'
+#' Grobid's `<row>`/`<cell>` structure makes no header/data distinction at all
+#' (unlike HTML's `<th>`/`<td>`) — but a real table's header can genuinely
+#' span SEVERAL leading rows (a super-header naming a group of columns, a
+#' sub-header, then the actual column names — confirmed against a real corpus
+#' paper's regression table: "Association with mean reappraisal" / "" /
+#' "β01 (SE)", three leading rows before any data). Treating only the first
+#' `<row>` as the header (as an earlier version of this function did) reads
+#' the REAL column names as if they were a data row, and scans genuine data as
+#' if it were headers. The leading rows are instead scanned from the top:
+#' every row whose cells are MOSTLY non-numeric (prose/blank, the shape a
+#' header or super-header row has) is folded into the header, stopping at the
+#' first row that looks like real data (mostly numeric/bracket/dash cells) —
+#' mirroring `.stat_table_parse()`'s own "last distinct-label row is the real
+#' header" heuristic, adapted for Grobid's lack of `<th>`. Folded header rows
+#' are joined per column with " / " (so "Association with" / "mean
+#' reappraisal" / "β01 (SE)" becomes one combined column name), which keeps
+#' the super-header's grouping information rather than discarding it.
+#'
+#' Ragged rows (a row with fewer/more cells than the header — GroBid's
+#' PDF-layout table detection is imperfect) are padded/truncated to the
+#' header's width rather than erroring, so one malformed row does not lose the
+#' rest of the table.
+#'
+#' @param tab_node the `<table>` xml2 node (or NA/NULL when the table was not
+#'   found)
+#'
+#' @returns a list of character vectors, `list(headers_row, ...data_rows)` (the
+#'   shape `inst/schema/paper.json`'s `table.contents` declares), or `NULL`
+#'   when the node is absent or has no rows
+#' @keywords internal
+.tei_table_contents <- function(tab_node) {
+  if (is.null(tab_node) || (length(tab_node) == 1 && is.na(tab_node))) return(NULL)
+
+  rows <- xml2::xml_find_all(tab_node, ".//row")
+  if (length(rows) == 0) return(NULL)
+
+  # Expand one <row>'s cells to a grid vector, repeating a cell's text across
+  # its `cols` span (default 1 when absent/invalid).
+  grid_of <- function(row) {
+    cells <- xml2::xml_find_all(row, ".//cell")
+    if (length(cells) == 0) return(character(0))
+    txt <- xml2::xml_text(cells, trim = TRUE) |> gsub("\\s+", " ", x = _)
+    span <- vapply(cells, function(c) {
+      n <- suppressWarnings(as.integer(xml2::xml_attr(c, "cols")))
+      if (is.na(n) || n < 1) 1L else n
+    }, integer(1))
+    rep(txt, times = span)
+  }
+
+  grids <- lapply(rows, grid_of)
+  width <- max(lengths(grids))
+  if (width == 0) return(NULL)
+
+  # Pad/truncate every row to the header's width so a ragged row (missing or
+  # extra cells) does not misalign the columns after it.
+  grids <- lapply(grids, function(g) {
+    length(g) <- width
+    g[is.na(g)] <- ""
+    g
+  })
+
+  # A row "looks like data" when most of its NON-EMPTY cells are numeric/
+  # value-shaped (a plain number, a bracketed CI, a lone dash placeholder) —
+  # the shape a real header/super-header row never has (its cells are prose
+  # column names, or blank where a span leaves a gap). ">= half" rather than
+  # "all", since a data row's own leading label cell ("1. Depression") is
+  # legitimately non-numeric text sitting alongside otherwise-numeric cells.
+  #
+  # A BARE small ordinal ("1.", "2.", ...: 1-2 digits, no decimal point) is
+  # explicitly EXCLUDED from "looks numeric" here — that shape is a matrix's
+  # own column-index header cell (a correlation matrix numbers its columns
+  # "1." … "6." to cross-reference the row labels), never a real reported
+  # value in this corpus (a decimal like "0.86", a range "0-32", or a dash
+  # placeholder always has a decimal point, a hyphen, or is the bare dash
+  # itself). Without this exclusion, a header row that is MOSTLY such
+  # ordinals ("Well-being measure | α | M (SD) | Actual | Possible | 1. | 2.
+  # | 3. | 4. | 5.") was itself misclassified as the first DATA row —
+  # confirmed against a real corpus paper's correlation-matrix table, whose
+  # own column-name header row was then scanned as if it were a result,
+  # producing nonsense "correlations" of exactly 1, 2, 3, 4, 5.
+  is_data_shaped <- function(g) {
+    nz <- g[nzchar(g)]
+    if (!length(nz)) return(FALSE)   # a wholly blank row is never data
+    is_ordinal <- grepl("^[0-9]{1,2}\\.?$", nz)
+    # Broad on purpose: a real reported value can carry trailing prose a
+    # strict full-string numeric pattern would reject ("0.059 (0.018)", a
+    # beta with its parenthetical SE; "6.38 (6.60)", a mean with its SD) — it
+    # only needs to START like a number/comparator, or be a bracketed
+    # interval, or the bare dash placeholder convention APA tables use for a
+    # diagonal/blank cell.
+    looks_numeric <- grepl("^[<>]?[-+]?[.0-9]", nz) | grepl("^\\[.*\\]$", nz) | nz == "-"
+    n_non_ord <- sum(!is_ordinal)
+    if (n_non_ord == 0) return(FALSE)   # a row of ONLY ordinals is the header
+    (sum(looks_numeric & !is_ordinal) / n_non_ord) >= 0.5 && mean(is_ordinal) < 0.5
+  }
+
+  header_end <- 1L
+  for (i in seq_along(grids)) {
+    if (is_data_shaped(grids[[i]])) { header_end <- i - 1L; break }
+    header_end <- i
+  }
+  header_end <- max(header_end, 1L)   # always at least one header row
+
+  if (header_end == 1L) {
+    header <- grids[[1]]
+  } else {
+    # Fold the leading header_end rows into one combined header, joining each
+    # column's text across those rows with " / " (blank contributions
+    # dropped, so a genuinely single-row-tall column name is not padded with
+    # empty " / " segments from a super-header that did not span it).
+    header <- vapply(seq_len(width), function(ci) {
+      parts <- vapply(grids[seq_len(header_end)], `[[`, character(1), ci)
+      parts <- parts[nzchar(parts)]
+      if (!length(parts)) "" else paste(parts, collapse = " / ")
+    }, character(1))
+  }
+
+  c(list(header), grids[-seq_len(header_end)])
+}
 
 
 #' Parse XML bib format to bibtex

--- a/R/import-read.R
+++ b/R/import-read.R
@@ -72,6 +72,7 @@ read <- function(file_path, include_images = FALSE, recursive = FALSE) {
   info[zeros] <- NA
   paper$info <- as.data.frame(info)
   paper$info$keywords <- I(list(keywords))
+  paper$info$abstract <- NULL # TODO: remove after bibr fixed
 
   # author ----
   if (!is.null(data$author) && length(data$author) > 0) {
@@ -99,6 +100,7 @@ read <- function(file_path, include_images = FALSE, recursive = FALSE) {
     if (!include_images) {
       paper$figure$image <- NA_character_
     }
+    paper$figure$caption <- NULL #tempfix
   }
 
   # url ----
@@ -116,6 +118,42 @@ read <- function(file_path, include_images = FALSE, recursive = FALSE) {
   # table ----
   if (!is.null(data$table) && length(data$table) > 0) {
     paper$table <- as.data.frame(data$table)
+    paper$table$caption <- NULL #tempfix
+
+    # `contents` is a RAGGED array of arrays (one row per table row, itself an
+    # array of cell strings — see .tei_table_contents() in R/import-grobid.R).
+    # The main read above uses simplifyVector/simplifyDataFrame = TRUE (needed
+    # for every OTHER field to come back as plain data frames), but jsonlite's
+    # simplifier reshapes THIS field into a 2D character matrix per table
+    # instead of preserving list(header_row, data_row, ...) — confirmed
+    # directly against a real corpus paper's table: a 16-row x 10-cell table
+    # round-tripped through simplifyVector = TRUE came back as a `chr[16,10]`
+    # matrix, not a 16-element list of 10-cell vectors, which broke
+    # extract_eq_table()'s row/header indexing silently (no error, just wrong
+    # results). Re-read ONLY the table section unsimplified and splice its
+    # `contents` back in, which keeps every other field's existing (correct)
+    # simplified shape untouched.
+    raw_tables <- tryCatch(
+      jsonlite::read_json(file_path, simplifyVector = FALSE)$table,
+      error = function(e) NULL)
+    if (!is.null(raw_tables) && length(raw_tables) == nrow(paper$table)) {
+      paper$table$contents <- lapply(raw_tables, function(t) {
+        rows <- t$contents
+        if (is.null(rows)) return(NULL)
+        # jsonlite::read_json(simplifyVector = FALSE) keeps EVERY JSON array
+        # as a list, never simplified — so each row comes back as a list of
+        # length-1 character strings, not a plain character vector. Every
+        # downstream table reader (.table_typed_cells(), .table_matrix_cols(),
+        # both in R/match-table.R) does VECTORISED string ops on a row
+        # (strsplit(header, ...), grepl() across a whole row at once), which
+        # error on a list rather than a character vector — confirmed as a
+        # real crash against a real corpus paper's table ("non-character
+        # argument" from strsplit()). unlist() each row back to a character
+        # vector, one level only (so a genuinely ragged/nested cell, if Grobid
+        # ever produced one, is not silently flattened further than this).
+        lapply(rows, function(r) unlist(r, use.names = FALSE))
+      })
+    }
   }
 
   # text ----

--- a/R/text-extractors.R
+++ b/R/text-extractors.R
@@ -126,10 +126,25 @@ extract_eq <- function(paper) {
 
   op <- operators |> paste(collapse = "")
   gr <- "\u0370-\u03FF" # greek |> paste(collapse = "")
+  # A real df-parenthetical is built from digits/commas/periods/whitespace,
+  # optionally interleaved with an "N = <number>" / "n = <number>" qualifier
+  # (as in "chi2(1, N = 200)") -- in EITHER order relative to the bare
+  # digits. What must NEVER appear inside is a DIFFERENT statistic's own
+  # name followed by its own operator (e.g. "beta = 0.74" or "t(260) ="),
+  # which is what an adjacent, unrelated clause parenthesised alongside this
+  # one looks like -- confirmed as a real bug: "significant (beta = 0.74,
+  # t(260) = 11.32)" matched the OLD unconstrained "(?:\\([^)]*\\))?" (any
+  # text up to the first literal ")", which is t(260)'s own close-paren, not
+  # the outer one) as if it were ONE statistic's df, fusing "significant",
+  # "beta = 0.74" and "t(260) =" into a single garbled, unrecognisable lhs
+  # and losing both real statistics entirely. Scoped narrowly (digits/N=
+  # only) so the still-common "chi2(1, N = 200)" shape keeps matching as one
+  # fragment exactly as before.
+  df_inner <- "(?:[0-9,\\.\\s]+|[nN]\\s*=\\s*[0-9]+)*"
   pattern <- paste0(
     "(?:(Hedge.{0,3}|Cronbach.{0,2}|Cohen.{0,2}|\\d{1,2}%)\\s+)?", # common prefix
     "[", gr, "\u00B2a-zA-Z-_\\.0-9\\{\\}\\^\\\\]+\\s*", # statistic name
-    "(?:\\([^)]*\\))?\\s*", # optional parentheses
+    "(?:\\(", df_inner, "\\))?\\s*", # optional df-shaped parentheses
     "[", op , "]{1,3}\\s*", # 1-3 operators
     "([0-9\\.,+-]*[0-9]|\\[[^\\]]+\\]|n\\.?\\s*s\\.?)", # valid numbers or anything in [] or NS
     "\\s*(e\\s*-\\d+)?", # also match scientific notation


### PR DESCRIPTION
## Summary

Core file-classification and text-extraction updates. No dependency on any other open PR.

### `R/file_category.R`
A statistics-package file that bundles **both** a dataset and its analyses (a `.jasp` / `.por`, typed `"data;stats"`) is now classified as **data**, since the dataset is the primary artifact and any bundled analyses are recovered separately as the code file. Other compound types (`code;web`, `code;exec`, `code;data`) keep their previous behaviour.

Codebook filename detection now requires a **two-word compound** throughout, with `[ _.-]?` separators so `"code book"`, `"code_book"`, `"code-book"` and dotted export names like `"Race_IAT.public.2025.codebook.csv"` all match.

The two-word requirement is deliberate and was checked against 27k real repository filenames: the single generic words are all substrings of ordinary data files — `meta_data.csv` and `encoding.csv` in that corpus are participant- and trial-level **data** — so matching bare `"metadata"`/`"codes"`/`"key"` would steal real datasets away from `data_check`, which is worse than missing a codebook.

### `R/import-grobid.R`
Adds `.tei_table_contents()`, which reads a Grobid `<table>` node's `<row>`/`<cell>` structure into a data frame.

Two things make this harder than parsing an HTML table:
- Grobid makes **no header/data distinction** at all (unlike HTML's `<th>`/`<td>`), and a real table's header can genuinely span several leading rows — a super-header naming a group of columns, then a sub-header, then the actual column names.
- A cell spanning several columns carries a `cols` attribute (Grobid's equivalent of `colspan`). Its text is expanded across the columns it covers, using the same grid-alignment approach `.stat_table_parse()` uses for JASP/jamovi colspans, so a spanning header cell still lines up with the data columns beneath it rather than shifting everything after it.

### `R/import-read.R`, `R/text-extractors.R`
Supporting extraction helpers.

## Test plan
- [ ] `devtools::test(filter = "import")` and `devtools::test(filter = "file")`
- [ ] Spot-check `.tei_table_contents()` against a Grobid TEI file with a multi-row / spanning header, since that's the case the grid alignment exists for