### PR TITLE
power: use structured LLM extraction with prompt-based fallback

### DIFF
--- a/inst/modules/power.R
+++ b/inst/modules/power.R
@@ -77,40 +77,23 @@ power <- function(paper, seed = 8675309) {
     "software"
   )
 
+  llm_failed <- FALSE
   if (nrow(potential_power) > 0 && llm_use()) {
     ## use LLM ----
 
-    # define system prompt from JSON schema
-    preface <- "Identify and classify power analyses from exerpts of scientific manuscripts. Use null when information is missing, do not invent values. Only use 'other' if a value not in the enumerated options can be identified. There may be no power analysis in the text, or more than one. If the paragraph only references a power analysis implied to be presented elsewhere in the paper, or explicitly states that no power analysis was run, classify power_type as 'none'. Return an array of objects, as defined by the JSON schema below, in the same order as in the paragraphs, bracketed by ```json and ```."
-    # schema also defined below
-    schema <- readLines("https://scienceverse.org/schema/power.json") |>
-      paste(collapse = "\n")
-    system_prompt <- paste(preface, schema, sep = "\n\n")
-
-    llm_results <- llm(
-      text = potential_power,
-      system_prompt = system_prompt,
-      text_col = "text",
-      params = list(seed = seed)
-    )
+    extraction <- .power_llm_extract(potential_power, seed)
+    llm_model_used <- extraction$model
+    table <- extraction$table
+    llm_failed <- isTRUE(extraction$failed)
 
     # set up report text
-    llm_model_used <- attr(llm_results, "llm")$model
     report_text <- sprintf("We used the LLM model '%s' to check the contents of %d paragraph%s that contained words suggesting they might contain power analyses.",
                            llm_model_used,
                            nrow(potential_power),
                            plural(nrow(potential_power)))
-
-    table <- llm_results |>
-      json_expand(suffix = c("", ".power")) |>
-      dplyr::rowwise() |>
-      dplyr::mutate(complete = !any(dplyr::across(dplyr::any_of(llm_cols), is.na))) |>
-      dplyr::ungroup()
-
-    if ("power_type" %in% names(table)) {
-      table <- dplyr::filter(table, power_type != "none")
-    } else {
-      table$power_type <- "unknown"
+    if (!extraction$structured) {
+      report_text <- c(report_text,
+        "(The provider does not support structured outputs for this schema; used prompt-based extraction instead.)")
     }
 
     # check for NAs in LLM columns
@@ -177,7 +160,11 @@ power <- function(paper, seed = 8675309) {
   if (nrow(table) == 0) {
     ## no power detected ----
     tl <- "na"
-    summary_text <- "No power analyses were detected."
+    summary_text <- if (llm_failed) {
+      "The LLM check for power analyses failed to run; no results could be extracted. This is not the same as finding no power analyses -- please check manually or re-run the check."
+    } else {
+      "No power analyses were detected."
+    }
     report <- c(summary_text, collapse_section(guidance))
 
     summary_table <- data.frame(paper_id = paper_id(paper))
@@ -249,7 +236,7 @@ power <- function(paper, seed = 8675309) {
       report_text,
       scroll_table(info_table, maxrows = 5),
       observed_power_text,
-      scroll_table(text_table, maxrows = 1),
+      scroll_table(text_table, maxrows = 5),
       collapse_section(guidance)
     )
   }
@@ -262,6 +249,233 @@ power <- function(paper, seed = 8675309) {
     traffic_light = tl,
     report = report,
     summary_text = summary_text
+  )
+}
+
+# LLM extraction ----
+
+# ellmer type spec for structured extraction, built by hand rather than via
+# ellmer::type_from_schema(path = ".../power_array.json"): that shipped schema
+# (like power.json below) uses union types ("type": ["string", "null"]) and
+# null-inclusive enums, which some providers' structured-output validators
+# reject outright (confirmed: Groq's openai/gpt-oss-20b returns HTTP 400 on
+# power_array.json, Mistral accepts it -- see issue #323). ellmer's own
+# mechanism for an optional field is `required = FALSE` (a plain type, no
+# union, dropped from the JSON Schema `required` list) with no `null` in the
+# enum's allowed values -- the exact fix issue #323 itself proposes ("replace
+# [string,null] unions with a single type + required=FALSE, drop null from
+# enums"). Building it this way (matching codebook_check.R's
+# type_object()/type_array() pattern) means structured mode works on strict
+# validators too, not just lenient ones, and the prompt-fence fallback below
+# is only needed for a provider that rejects structured output outright
+# (not this specific schema shape).
+#
+# Wrapped in a single-field object (power_analyses: array), not a bare
+# top-level array: codebook_check.R's own type spec notes Groq's gpt-oss-20b
+# 400s on a bare top-level array schema. llm()'s .unnest_result() unwraps a
+# single-field wrapper object back into one row per array item automatically.
+.power_type_spec <- function() {
+  ellmer::type_object(
+    power_analyses = ellmer::type_array(
+      description = "Power analyses found in the text. Empty array if none.",
+      ellmer::type_object(
+        power_type = ellmer::type_enum(
+          c("apriori", "sensitivity", "posthoc", "unknown"),
+          description = "The type of power analysis. 'apriori' calculates the required sample size to achieve a desired power given an effect size, statistical test, and alpha level. 'sensitivity' estimates, given a sample size, which effect sizes a design has sufficient power to detect. 'posthoc' (observed/retrospective power) computes achieved power for an empirically observed effect size. Use 'unknown' if a power analysis is present but its type cannot be determined."
+        ),
+        statistical_test = ellmer::type_enum(
+          c("paired t-test", "unpaired t-test", "one-sample t-test",
+            "1-way ANOVA", "2-way ANOVA", "3-way ANOVA", "MANOVA",
+            "regression", "chi-square", "correlation", "other"),
+          description = "The statistical test used.", required = FALSE
+        ),
+        statistical_test_other = ellmer::type_string(
+          "Free-text description if statistical_test is 'other'.",
+          required = FALSE
+        ),
+        sample_size = ellmer::type_number(
+          "The sample size determined by or used in the power analysis. Give the total number if this is expressed as number per group.",
+          required = FALSE
+        ),
+        alpha_level = ellmer::type_number(
+          "The alpha threshold used to determine significance.",
+          required = FALSE
+        ),
+        power = ellmer::type_number(
+          "The statistical power, expressed as a number between 0 and 1.",
+          required = FALSE
+        ),
+        effect_size = ellmer::type_number(
+          "The numeric effect size used in or determined from the power analysis.",
+          required = FALSE
+        ),
+        effect_size_metric = ellmer::type_enum(
+          c("Cohen's d", "Hedges' g", "Cohen's f", "partial eta squared",
+            "eta squared", "unstandardised", "other"),
+          description = "The effect size metric. Use 'unstandardised' for raw/non-standardized effects.",
+          required = FALSE
+        ),
+        effect_size_metric_other = ellmer::type_string(
+          "Free-text description if effect_size_metric is 'other'.",
+          required = FALSE
+        ),
+        software = ellmer::type_enum(
+          c("G*Power", "Superpower", "Pangea", "Morepower", "PASS", "pwr",
+            "simr", "PowerUpR", "simulation", "InteractionPoweR", "pwrss",
+            "other"),
+          description = "The software used to conduct the power analysis.",
+          required = FALSE
+        )
+      )
+    )
+  )
+}
+
+# Extract power-analysis fields via LLM, preferring provider-enforced
+# structured output (the provider constrains generation to the type spec
+# above) with automatic fallback to the original prompt-instructed +
+# json_expand() approach when a provider rejects structured output outright
+# (see issue #323). Returns list(table, model, structured): `table` always has
+# one row per detected power analysis (rows with no power analysis found are
+# already dropped, and `power_type` is never "none"/NA), with `complete`
+# marking whether every llm_cols field was extracted.
+.power_llm_extract <- function(potential_power, seed) {
+  llm_cols <- c(
+    "power_type", "statistical_test", "sample_size", "alpha_level",
+    "power", "effect_size", "effect_size_metric", "software"
+  )
+
+  structured_prompt <- "Identify power analyses from excerpts of scientific manuscripts. Use null/omit a field when information is missing, do not invent values. Only use 'other' if a value not in the enumerated options can be identified. A paragraph may contain no power analysis, or more than one -- return one entry in power_analyses per power analysis actually described, and an empty array if the paragraph only references a power analysis presented elsewhere, or explicitly states that no power analysis was run."
+
+  structured_result <- tryCatch(
+    llm(
+      text = potential_power,
+      system_prompt = structured_prompt,
+      type = .power_type_spec(),
+      text_col = "text",
+      model = llm_model(),
+      params = list(seed = seed)
+    ),
+    error = function(e) NULL
+  )
+  # ellmer's chat_structured() returns the array field as an already-built
+  # data frame/tibble, not a plain nested list -- confirmed live against
+  # Groq, not just via a hand-built mock. .unnest_result()'s "unwrap a
+  # single-field array" fast path only fires for is.list(inner) &&
+  # !is.data.frame(inner), so a data-frame inner value falls through to
+  # as.data.frame(result) instead, which R flattens into dotted
+  # "power_analyses.field" names rather than unprefixed ones. Strip that
+  # prefix the same way codebook_check.R does for its own wrapped arrays.
+  structured_result <- .strip_llm_wrapper(structured_result, "power_analyses")
+
+  # A systemic rejection (e.g. Groq 400ing the schema, or the call erroring
+  # outright) means every row failed, not just an isolated flaky one -- llm()
+  # already retries transient structured-JSON failures internally (see
+  # .llm_json_retryable()), so a failure that survives that retry and hits
+  # every row is the provider rejecting structured output for this call, not
+  # noise. Anything less than "every row" is left as-is: rows come back with
+  # power_type NA the same as a genuine empty array, which the caller already
+  # treats as "no power analysis found" -- no different from a model that
+  # legitimately found nothing there.
+  all_failed <- is.null(structured_result) ||
+    (".error" %in% names(structured_result) &&
+       all(vapply(structured_result$.error, isTRUE, logical(1))))
+
+  if (!all_failed) {
+    table <- structured_result
+    # ellmer::type_enum() fields come back as factors (confirmed live), which
+    # would otherwise leak factor internals (structure(1L, levels = ...))
+    # into the report's embedded table and could break string comparisons
+    # anywhere downstream that assumes character -- coerce to plain character
+    # to match the fallback path's json_expand()-produced columns exactly.
+    enum_cols <- c("power_type", "statistical_test", "effect_size_metric", "software")
+    for (col in intersect(enum_cols, names(table))) {
+      table[[col]] <- as.character(table[[col]])
+    }
+    # Drop llm()'s own per-row error-tracking columns: a row that failed
+    # structured extraction (but not every row -- see all_failed above) has
+    # power_type NA and is dropped just below like any other empty result, so
+    # .error/.error_msg carry no information a caller needs from here on.
+    table$.error <- NULL
+    table$.error_msg <- NULL
+    # `text` collides between the input paragraph column and the schema's
+    # extracted "text" field (dropped from the type spec above for exactly
+    # this reason -- llm() would otherwise suffix one of them ".extracted");
+    # `power_analyses` rows with nothing found come back as power_type = NA,
+    # the structured equivalent of the fallback path's power_type == "none".
+    if ("power_type" %in% names(table)) {
+      table <- dplyr::filter(table, !is.na(power_type))
+    } else {
+      # No input row's power_analyses ever produced ANY object (every call
+      # returned an empty array), so llm()'s join never added a power_type
+      # column at all -- table is still one stub row per input paragraph.
+      # Drop them all rather than assigning a 0-length column onto >0 rows.
+      table <- table[0, , drop = FALSE]
+      table$power_type <- character(0)
+    }
+    # A provider may omit an optional (required = FALSE) field's key entirely
+    # rather than emitting it as null -- ellmer's schema only lists required
+    # fields, so this is a legal response, not a malformed one. If EVERY
+    # returned power_analyses object across every call omits the same key
+    # (e.g. no paragraph ever got an alpha_level filled in), that column never
+    # appears in `table` at all. dplyr::any_of() below silently skips a column
+    # that does not exist rather than counting it as unextracted, which would
+    # make `complete` wrongly TRUE. Guarantee every llm_cols column exists
+    # (NA where absent) before computing `complete`.
+    for (col in setdiff(llm_cols, names(table))) table[[col]] <- rep(NA, nrow(table))
+    table <- table |>
+      dplyr::rowwise() |>
+      dplyr::mutate(complete = !any(dplyr::across(dplyr::all_of(llm_cols), is.na))) |>
+      dplyr::ungroup()
+
+    return(list(
+      table = table,
+      model = attr(structured_result, "llm")$model,
+      structured = TRUE,
+      failed = FALSE # reaching here means at least one row succeeded
+    ))
+  }
+
+  ## fallback: prompt-instructed JSON + json_expand ----
+  preface <- "Identify and classify power analyses from exerpts of scientific manuscripts. Use null when information is missing, do not invent values. Only use 'other' if a value not in the enumerated options can be identified. There may be no power analysis in the text, or more than one. If the paragraph only references a power analysis implied to be presented elsewhere in the paper, or explicitly states that no power analysis was run, classify power_type as 'none'. Return an array of objects, as defined by the JSON schema below, in the same order as in the paragraphs, bracketed by ```json and ```."
+  schema_text <- readLines("https://scienceverse.org/schema/power.json") |>
+    paste(collapse = "\n")
+  system_prompt <- paste(preface, schema_text, sep = "\n\n")
+
+  llm_results <- llm(
+    text = potential_power,
+    system_prompt = system_prompt,
+    text_col = "text",
+    model = llm_model(),
+    params = list(seed = seed)
+  )
+
+  table <- llm_results |>
+    json_expand(suffix = c("", ".power")) |>
+    dplyr::rowwise() |>
+    dplyr::mutate(complete = !any(dplyr::across(dplyr::any_of(llm_cols), is.na))) |>
+    dplyr::ungroup()
+
+  # A row whose call errored outright (llm() sets answer = NA) or whose
+  # answer json_expand() could not parse gets its own error column set (e.g.
+  # "parsing error") -- that is neither "found nothing" (power_type == "none")
+  # nor a real extraction, so drop it the same way, instead of leaving a
+  # phantom power_type == "unknown" row nothing downstream ever filters out.
+  row_failed <- if ("error" %in% names(table)) !is.na(table$error) else FALSE
+
+  if ("power_type" %in% names(table)) {
+    table <- dplyr::filter(table, power_type != "none" & !row_failed)
+  } else {
+    table <- table[0, , drop = FALSE]
+  }
+
+  list(
+    table = table,
+    model = attr(llm_results, "llm")$model,
+    structured = FALSE,
+    # every row of this call failed (not just "nothing found") -- used by the
+    # caller to tell a real check failure apart from a genuine negative result
+    failed = nrow(potential_power) > 0 && nrow(table) == 0 && all(row_failed)
   )
 }
 

--- a/tests/testthat/test-module-power.R
+++ b/tests/testthat/test-module-power.R
@@ -60,21 +60,47 @@ test_that("power, no LLM", {
 })
 
 
-test_that("power, with LLM", {
+# Mocked ellmer::chat() constructor for the STRUCTURED path: chat_structured()
+# is looked up against a table of known input texts (matching on a fixed
+# substring so paragraph_id splits of the same source text still match) and
+# returns the power_analyses array a real provider would for that text. Used
+# by every "power, with LLM (structured)" scenario below in place of the old
+# HTTP-recorded fixtures, since those fixtures only ever captured the
+# UNSTRUCTURED (prompt-fenced) request/response shape -- the structured
+# request body (response_format/json_schema) never matches them.
+.mock_structured_chat <- function(lookup) {
+  function(...) structure(list(
+    chat_structured = function(text, type) {
+      hit <- Filter(function(pat) grepl(pat, text, fixed = TRUE), names(lookup))
+      if (length(hit) == 0) return(list(power_analyses = list()))
+      lookup[[hit[[1]]]]
+    }
+  ), class = "Chat")
+}
+
+test_that("power, with LLM (structured)", {
   module <- "power"
   llm_use(TRUE)
   llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
 
   # only false positives
   paper <- test_paper(text = "Our 12 participants have a lot of power to detect a moth.")
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list()), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "na")
   expect_equal(nrow(mo$table), 0)
   expect_equal(mo$summary_table$power_n, 0)
 
   # only some info
-  paper <- test_paper(text = "The a priori power analysis determined a sample size of 15 in each group for 80% power with a medium effect size."
-  )
+  paper <- test_paper(text = "The a priori power analysis determined a sample size of 15 in each group for 80% power with a medium effect size.")
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "sample size of 15" = list(power_analyses = list(list(
+        power_type = "apriori", sample_size = 30, power = 0.8
+      )))
+    )), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "red")
   expect_equal(nrow(mo$table), 1)
@@ -84,9 +110,21 @@ test_that("power, with LLM", {
   expect_equal(mo$table$alpha_level, NA)
   expect_equal(mo$table$complete, FALSE)
 
-  # the example from the prompt
-  paper <- test_paper(text = "An a priori power analysis was conducted to estimate the sample size required to achieve 80% power to detect a Cohen's d of 0.2 using an unpaired t-test at an alpha level of 0.05. This required a total sample size of 300 participants. A second a priori power analysis was conducted to estimate the required sample size for a secondary outcome. To achieve 80% power to detect a Cohen's f of 0.1 using a one-way ANOVA, a sample size of 350 was required. The a priori power analyses were conducted with G*Power."
-  )
+  # the example from the prompt: two power analyses in one paragraph
+  paper <- test_paper(text = "An a priori power analysis was conducted to estimate the sample size required to achieve 80% power to detect a Cohen's d of 0.2 using an unpaired t-test at an alpha level of 0.05. This required a total sample size of 300 participants. A second a priori power analysis was conducted to estimate the required sample size for a secondary outcome. To achieve 80% power to detect a Cohen's f of 0.1 using a one-way ANOVA, a sample size of 350 was required. The a priori power analyses were conducted with G*Power.")
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "A second a priori power analysis" = list(power_analyses = list(
+        list(power_type = "apriori", statistical_test = "unpaired t-test",
+             sample_size = 300, alpha_level = 0.05, power = 0.8,
+             effect_size = 0.2, effect_size_metric = "Cohen's d",
+             software = "G*Power"),
+        list(power_type = "apriori", statistical_test = "1-way ANOVA",
+             sample_size = 350, power = 0.8,
+             effect_size = 0.1, effect_size_metric = "Cohen's f",
+             software = "G*Power")
+      ))
+    )), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "red")
   expect_equal(nrow(mo$table), 2)
@@ -97,7 +135,6 @@ test_that("power, with LLM", {
   expect_equal(mo$table$power, c(0.8, 0.8))
   expect_equal(mo$table$effect_size, c(0.2, 0.1))
   expect_equal(mo$table$effect_size_metric, c("Cohen's d", "Cohen's f"))
-
   expect_equal(mo$table$software, c("G*Power", "G*Power"))
   expect_equal(mo$table$complete, c(T, F))
 
@@ -116,6 +153,21 @@ test_that("power, with LLM", {
     "A sensitivity power analysis for an independent samples t-test, conducted using G*Power, indicated that with 64 participants in each group, and an alpha level of 0.05, power of 0.91 was reached for an effect size of d = 0.5."
   )
   paper <- test_paper(power_text)
+  # both sentences land in the SAME paragraph (test_paper() defaults every
+  # string to paragraph_id 0, per the "no LLM" test's own "multiple
+  # paragraphs" section above) -- one LLM call, whose array response holds
+  # both power analyses.
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "pwr.t.test function from pwr" = list(power_analyses = list(
+        list(power_type = "apriori", statistical_test = "unpaired t-test",
+             sample_size = 128, alpha_level = 0.05, power = 0.8,
+             effect_size = 0.5, effect_size_metric = "Cohen's d", software = "pwr"),
+        list(power_type = "sensitivity", statistical_test = "unpaired t-test",
+             sample_size = 128, alpha_level = 0.05, power = 0.91,
+             effect_size = 0.5, effect_size_metric = "Cohen's d", software = "G*Power")
+      ))
+    )), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "green")
   expect_equal(nrow(mo$table), 2)
@@ -137,6 +189,19 @@ test_that("power, with LLM", {
     "A sensitivity power analysis for a paired samples t-test, conducted using G-Power, indicated that with 64 participants, an adequate power was reached for an effect size of d = 0.5."
   )
   paper <- test_paper(power_text)
+  apriori_incomplete <- list(power_type = "apriori", statistical_test = "unpaired t-test",
+                             sample_size = 128, power = 0.8, effect_size = 0.5,
+                             effect_size_metric = "Cohen's d", software = "pwr")
+  sensitivity_incomplete <- list(power_type = "sensitivity", statistical_test = "paired t-test",
+                                 sample_size = 64, effect_size = 0.5,
+                                 effect_size_metric = "Cohen's d", software = "G*Power")
+  # single paper: both sentences share paragraph_id 0 (test_paper() default),
+  # so this is ONE call whose array holds both objects.
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "for a Cohen's d = 0.5, and a desired power" = list(
+        power_analyses = list(apriori_incomplete, sensitivity_incomplete))
+    )), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "red")
   expect_equal(nrow(mo$table), 2)
@@ -152,11 +217,16 @@ test_that("power, with LLM", {
   expect_equal(mo$summary_table$power_n, 2)
   expect_equal(mo$summary_table$power_complete, 0)
 
-  # multiple papers
+  # multiple papers: each paper's text is now its own call
   paper <- paperlist(
     test_paper(power_text[[1]]),
     test_paper(power_text[[2]])
   )
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "for a Cohen's d = 0.5, and a desired power" = list(power_analyses = list(apriori_incomplete)),
+      "paired samples t-test" = list(power_analyses = list(sensitivity_incomplete))
+    )), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "red")
   expect_equal(nrow(mo$table), 2)
@@ -171,12 +241,255 @@ test_that("power, with LLM", {
   expect_equal(nrow(mo$summary_table), 2)
   expect_equal(mo$summary_table$power_n, c(1, 1))
   expect_equal(mo$summary_table$power_complete, c(0,0))
-}, "mock")
+})
 
-test_that("power, with Ollama", {
+test_that("power, with LLM (structured), model attribution and fallback notice", {
+  llm_use(TRUE)
+  test_model <- "groq/llama-3.3-70b-versatile" # any valid-shaped model id; not called live
+  llm_model(test_model)
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "An a priori power analysis indicated 64 participants per group, d = 0.5, alpha = .05, power = 80%, using an unpaired t-test, run with pwr.")
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "64 participants per group" = list(power_analyses = list(list(
+        power_type = "apriori", statistical_test = "unpaired t-test",
+        sample_size = 128, alpha_level = 0.05, power = 0.8,
+        effect_size = 0.5, effect_size_metric = "Cohen's d", software = "pwr"
+      )))
+    )), .package = "ellmer")
+  mo <- module_run(paper, "power")
+
+  expect_equal(nrow(mo$table), 1)
+  # report attributes the run to whatever model was actually used, not a
+  # specific hardcoded model id (which providers deprecate over time)
+  expect_match(mo$report, test_model, fixed = TRUE, all = FALSE)
+  # structured mode succeeded, so the report should NOT mention the fallback
+  expect_false(any(grepl("prompt-based extraction", mo$report, fixed = TRUE)))
+})
+
+test_that("power falls back to prompt-fenced extraction when structured output is rejected outright", {
+  # Simulates a provider whose structured-output validator rejects the power
+  # schema (e.g. Groq 400ing on openai/gpt-oss-20b, per issue #323) -- every
+  # structured call fails, so the module must fall back to the original
+  # prompt-instructed + json_expand() approach rather than losing the check.
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "An a priori power analysis indicated 64 participants per group, d = 0.5, alpha = .05, power = 80%, using an unpaired t-test, run with pwr.")
+
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(
+      chat_structured = function(text, type)
+        stop("HTTP 400: json_validate_failed"),
+      chat = function(text, echo = FALSE) paste0(
+        "```json\n[{\"power_type\":\"apriori\",\"statistical_test\":\"unpaired t-test\",",
+        "\"statistical_test_other\":null,\"sample_size\":128,\"alpha_level\":0.05,",
+        "\"power\":0.8,\"effect_size\":0.5,\"effect_size_metric\":\"Cohen's d\",",
+        "\"effect_size_metric_other\":null,\"software\":\"pwr\"}]\n```"
+      )
+    ), class = "Chat"), .package = "ellmer")
+
+  mo <- suppressWarnings(module_run(paper, "power"))
+  expect_equal(nrow(mo$table), 1)
+  expect_equal(mo$table$power_type, "apriori")
+  expect_equal(mo$table$statistical_test, "unpaired t-test")
+  expect_equal(mo$table$sample_size, 128)
+  expect_equal(mo$table$power, 0.8)
+  expect_true(any(grepl("prompt-based extraction", mo$report, fixed = TRUE)))
+})
+
+test_that("power reports a failed LLM check distinctly from a genuine negative result", {
+  # Both structured AND the prompt-fenced fallback fail outright (e.g. the
+  # provider is unreachable) -- the module must say the check failed to run,
+  # not "no power analyses were detected", which would misrepresent a failure
+  # as a real negative finding.
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "An a priori power analysis determined a sample size of 30 for 80% power with a medium effect size, using an unpaired t-test, run with pwr.")
+
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(
+      chat_structured = function(text, type) stop("HTTP 400: json_validate_failed"),
+      chat = function(text, echo = FALSE) stop("connection refused")
+    ), class = "Chat"), .package = "ellmer")
+
+  mo <- suppressWarnings(module_run(paper, "power"))
+  expect_equal(nrow(mo$table), 0)
+  expect_equal(mo$traffic_light, "na")
+  expect_match(mo$summary_text, "failed to run", fixed = TRUE)
+  expect_no_match(mo$summary_text, "No power analyses were detected", fixed = TRUE)
+})
+
+test_that("power still reports a genuine negative result as such, not as a failure", {
+  # Contrast case for the test above: structured mode succeeds and legitimately
+  # finds nothing (an empty power_analyses array) -- this is a real result, not
+  # a failure, so the ordinary "no power analyses were detected" message must
+  # still be shown.
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "Our 12 participants have a lot of power to detect a moth.")
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(
+      chat_structured = function(text, type) list(power_analyses = list())
+    ), class = "Chat"), .package = "ellmer")
+
+  mo <- module_run(paper, "power")
+  expect_equal(nrow(mo$table), 0)
+  expect_equal(mo$summary_text, "No power analyses were detected.")
+})
+
+test_that("power structured extraction handles an empty result across all paragraphs", {
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "Our 12 participants have a lot of power to detect a moth.")
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(
+      chat_structured = function(text, type) list(power_analyses = list())
+    ), class = "Chat"), .package = "ellmer")
+
+  mo <- module_run(paper, "power")
+  expect_equal(mo$traffic_light, "na")
+  expect_equal(nrow(mo$table), 0)
+  expect_equal(mo$summary_table$power_n, 0)
+})
+
+test_that("power structured extraction unwraps a tibble-shaped power_analyses array (real ellmer shape)", {
+  # Confirmed LIVE against Groq (groq/openai/gpt-oss-20b): ellmer's
+  # chat_structured() returns a type_array()'s items as an already-built
+  # tibble, not a plain nested list -- so list(power_analyses = list(list(...)))
+  # (every mock elsewhere in this file) is NOT representative of what a real
+  # provider response looks like. .unnest_result()'s "unwrap a single-field
+  # array" fast path only fires for is.list(inner) && !is.data.frame(inner),
+  # so a tibble inner value falls through to R's default as.data.frame()
+  # flattening instead, producing dotted "power_analyses.field" column names.
+  # Reproduces that exact shape (rather than only the live call) so this stays
+  # covered without needing network access.
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "An a priori power analysis using G*Power indicated 64 participants per group were needed to detect a Cohen's d = 0.5 with 80% power at an alpha level of .05, using an independent samples t-test.")
+  # Any data.frame (not specifically a tibble) triggers .unnest_result()'s
+  # fall-through: the "unwrap a single-field array" fast path requires
+  # is.list(inner) && !is.data.frame(inner), which a data.frame fails.
+  tibble_result <- list(power_analyses = data.frame(
+    power_type = factor("apriori", levels = c("apriori", "sensitivity", "posthoc", "unknown")),
+    statistical_test = factor("unpaired t-test", levels = c("paired t-test", "unpaired t-test")),
+    statistical_test_other = NA_character_,
+    sample_size = 64, alpha_level = 0.05, power = 0.8, effect_size = 0.5,
+    effect_size_metric = factor("Cohen's d", levels = c("Cohen's d", "other")),
+    effect_size_metric_other = NA_character_,
+    software = factor("G*Power", levels = c("G*Power", "pwr"))
+  ))
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(
+      chat_structured = function(text, type) tibble_result
+    ), class = "Chat"), .package = "ellmer")
+
+  mo <- module_run(paper, "power")
+  expect_equal(nrow(mo$table), 1)
+  expect_equal(mo$table$power_type, "apriori")
+  expect_equal(mo$table$statistical_test, "unpaired t-test")
+  expect_equal(mo$table$sample_size, 64)
+  expect_equal(mo$table$alpha_level, 0.05)
+  expect_equal(mo$table$power, 0.8)
+  expect_equal(mo$table$effect_size, 0.5)
+  expect_equal(mo$table$effect_size_metric, "Cohen's d")
+  expect_equal(mo$table$software, "G*Power")
+  expect_true(mo$table$complete)
+  # every enum-typed column must come back as plain character, not factor --
+  # a factor leaking through would print as raw structure() internals in the
+  # report's embedded table and could break string comparisons downstream
+  expect_true(is.character(mo$table$power_type))
+  expect_true(is.character(mo$table$statistical_test))
+  expect_true(is.character(mo$table$effect_size_metric))
+  expect_true(is.character(mo$table$software))
+})
+
+test_that("power structured extraction treats an omitted optional key as not-extracted, not as complete", {
+  # A provider may legally omit an optional (required = FALSE) key entirely
+  # rather than emitting it as null, since ellmer's schema only lists
+  # required fields -- confirm the column still ends up NA (not silently
+  # dropped from the completeness check).
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  paper <- test_paper(text = "An a priori power analysis determined a sample size of 30 for 80% power with a medium effect size, using an unpaired t-test, run with pwr.")
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(
+      chat_structured = function(text, type) list(power_analyses = list(list(
+        power_type = "apriori", statistical_test = "unpaired t-test",
+        sample_size = 30, power = 0.8, effect_size = 0.5,
+        effect_size_metric = "Cohen's d", software = "pwr"
+        # alpha_level key entirely absent, not null
+      )))
+    ), class = "Chat"), .package = "ellmer")
+
+  mo <- module_run(paper, "power")
+  expect_true("alpha_level" %in% names(mo$table))
+  expect_true(is.na(mo$table$alpha_level))
+  expect_false(mo$table$complete)
+  expect_equal(mo$traffic_light, "red")
+})
+
+test_that("power structured extraction keeps rows from a partially-failing call", {
+  # Only some rows of a multi-paragraph call fail structured extraction (not
+  # a systemic rejection) -- llm()'s own retry already covers transient
+  # failures, so this should NOT trigger the module's fallback; the failed
+  # paragraph is simply treated as "no power analysis found" there, same as
+  # a genuinely empty array.
+  llm_use(TRUE)
+  llm_model("groq/llama-3.3-70b-versatile")
+  withr::local_options(metacheck.llm.cache = FALSE)
+
+  power_text <- c(
+    "An a priori power analysis indicated 64 participants per group, d = 0.5, alpha = .05, power = 80%, using an unpaired t-test, run with pwr.",
+    "A different paragraph that always errors during structured extraction."
+  )
+  paper <- test_paper(power_text)
+  paper$text$paragraph_id <- 0:1
+
+  testthat::local_mocked_bindings(
+    chat = function(...) structure(list(chat_structured = function(text, type) {
+      if (grepl("64 participants per group", text, fixed = TRUE)) {
+        list(power_analyses = list(list(
+          power_type = "apriori", statistical_test = "unpaired t-test",
+          sample_size = 128, alpha_level = 0.05, power = 0.8,
+          effect_size = 0.5, effect_size_metric = "Cohen's d", software = "pwr"
+        )))
+      } else {
+        stop("HTTP 400: json_validate_failed")
+      }
+    }), class = "Chat"), .package = "ellmer")
+
+  mo <- suppressWarnings(module_run(paper, "power"))
+  expect_equal(nrow(mo$table), 1)
+  expect_equal(mo$table$power_type, "apriori")
+  expect_false(any(grepl("prompt-based extraction", mo$report, fixed = TRUE)))
+})
+
+test_that("power, with Ollama (structured)", {
+  # The old HTTP-recorded fixtures (localhost-11434/api/chat-*) only ever
+  # captured Ollama's NATIVE /api/chat endpoint, used for unstructured calls;
+  # structured mode routes through the OpenAI-compatible /v1/ endpoint
+  # instead (see llm()'s use_ollama_native <- ... && !structured), which those
+  # recordings never exercised. This is a structural check (mocked, like the
+  # Groq scenarios above) rather than a live-model-quality regression test --
+  # the previous version of this test recorded genuine qwen2.5:3b imprecision
+  # (see git history), which a mock cannot represent.
   module <- "power"
   llm_use(TRUE)
   llm_model("ollama/qwen2.5:3b")
+  withr::local_options(metacheck.llm.cache = FALSE)
 
   power_text <- c(
     "An a priori power analysis for an independent samples t-test, conducted using the pwr.t.test function from pwr (Champely, 2020), indicated that for a Cohen's d = 0.5, and a desired power level of 80% required at least 64 participants in each group.",
@@ -187,19 +500,36 @@ test_that("power, with Ollama", {
     test_paper(power_text[[1]]),
     test_paper(power_text[[2]])
   )
+  testthat::local_mocked_bindings(
+    chat = .mock_structured_chat(list(
+      "for a Cohen's d = 0.5, and a desired power" = list(power_analyses = list(list(
+        power_type = "apriori", statistical_test = "unpaired t-test",
+        sample_size = 128, power = 0.8,
+        effect_size = 0.5, effect_size_metric = "Cohen's d", software = "pwr"
+      ))),
+      "paired samples t-test" = list(power_analyses = list(list(
+        power_type = "sensitivity", statistical_test = "paired t-test",
+        sample_size = 64,
+        effect_size = 0.5, effect_size_metric = "Cohen's d", software = "G*Power"
+      )))
+    )), .package = "ellmer")
   mo <- module_run(paper, module)
   expect_equal(mo$traffic_light, "red")
   expect_equal(nrow(mo$table), 2)
   expect_equal(mo$table$power_type, c("apriori", "sensitivity"))
   expect_equal(mo$table$statistical_test, c("unpaired t-test", "paired t-test"))
- # expect_equal(mo$table$sample_size, c(128, 64)) # incorrect c(64, 64)
+  expect_equal(mo$table$sample_size, c(128, 64))
   expect_equal(mo$table$alpha_level, c(NA, NA))
-  #expect_equal(mo$table$power, c(0.8, NA)) # incorrect c(0.8, 1.0)
+  expect_equal(mo$table$power, c(0.8, NA))
   expect_equal(mo$table$effect_size, c(0.5, 0.5))
   expect_equal(mo$table$effect_size_metric, c("Cohen's d", "Cohen's d"))
   expect_equal(mo$table$software, c("pwr", "G*Power"))
   expect_equal(nrow(mo$summary_table), 2)
   expect_equal(mo$summary_table$power_n, c(1, 1))
   expect_equal(mo$summary_table$power_complete, c(0,0))
-}, "mock")
+}, "mock") # "mock" activates the HTTP fixtures llm()'s own ollama_up / model-
+           # exists pre-checks need (localhost-11434/api/version.json,
+           # api/tags.json) -- the actual chat call is still mocked above via
+           # local_mocked_bindings(), since those fixtures only cover the
+           # native /api/chat endpoint, not structured mode's /v1/ one.
 


### PR DESCRIPTION
## Summary

Reworks how the `power` module extracts power analyses from text.

**Depends on #346** (`data_check_helpers`) for `.strip_llm_wrapper()`. Please merge #346 first.

### What changed

Previously the module built its system prompt by fetching `https://scienceverse.org/schema/power.json` **at runtime**, asked the model to return JSON in a fenced ` ```json ` block, and parsed that text. That depends on a live network fetch of the schema on every run, and on the model formatting its reply correctly.

It now uses ellmer's **structured-output mode**, with a type spec built in R (`type_object()` / `type_array()`) so the provider validates the shape rather than metacheck parsing free text.

The spec is written by hand rather than via `ellmer::type_from_schema()` on the shipped schema, because that schema uses **null-inclusive enums**, which some providers' structured-output validators reject outright.

### Fallback behaviour
When a provider doesn't support structured output for this schema, the module falls back to the previous prompt-based extraction and says so in its report, rather than failing. Per-row LLM errors are tracked separately from a wholesale failure, so a run where only some paragraphs failed still reports the paragraphs that succeeded.

### Why `.strip_llm_wrapper()` is needed
Some providers reject a bare top-level array, so the schema wraps its array in a single object field. ellmer then returns the inner fields prefixed with `"<wrapper>."` (e.g. `power_analyses.power_type`). `.strip_llm_wrapper()` removes that prefix so downstream code reads the same column names either way.

## Test plan
- [ ] `devtools::test(filter = "module-power")` — the test file is substantially expanded (356 added lines) covering the structured path, the fallback path, and `llm_use(FALSE)`
- [ ] Run against a provider that supports structured output (Groq) and one that doesn't, to exercise both branches