### PR TITLE
Fix per-paper summary_table aggregation across repo_check, data_check, codebook_check

### DIFF
--- a/R/data_check_helpers.R
+++ b/R/data_check_helpers.R
@@ -2577,7 +2577,8 @@ normalize_label <- function(x) {
     value_labels = character(0), missing_values = character(0),
     question = character(0),
     coding_instructions = character(0),
-    parse_method = character(0)
+    parse_method = character(0),
+    paper_id = character(0)
   )
 }
 
@@ -4163,8 +4164,27 @@ match_column_labels <- function(columns_df, codebook_vars_df) {
       if (length(v) > 0) as.character(v[1]) else NA_character_
     } else NA_character_
 
+  # A codebook variable must belong to the SAME paper as the column it labels.
+  # Without this, a column named e.g. "age" or "condition" (extremely common
+  # across unrelated studies) would match ANY paper's codebook variable of the
+  # same normalised name when this function runs once across a whole
+  # paperlist -- columns_df/codebook_vars_df both span every paper in that
+  # case, not just one. columns_df always carries paper_id (from data_check),
+  # and codebook_check.R stamps it onto codebook_vars_df too -- but this
+  # function is also called directly in tests with a minimal codebook_vars_df
+  # that has no paper_id column at all, so that case falls back to the
+  # pre-fix behaviour (match by name only) rather than silently matching
+  # nothing.
+  col_paper_id <- columns_df$paper_id %||% rep(NA_character_, n)
+  has_var_paper_id <- "paper_id" %in% names(codebook_vars_df)
+  var_paper_id <- if (has_var_paper_id) codebook_vars_df$paper_id else NULL
+
   for (i in seq_len(n)) {
-    name_idx <- which(norm_var == norm_col[i])
+    name_idx <- if (has_var_paper_id) {
+      which(norm_var == norm_col[i] & var_paper_id == col_paper_id[i])
+    } else {
+      which(norm_var == norm_col[i])
+    }
     if (length(name_idx) == 0) next
     cg <- col_group[i]
 

--- a/inst/modules/code_check.R
+++ b/inst/modules/code_check.R
@@ -144,6 +144,16 @@ code_check <- function(paper, local_path = NULL,
   # no relevant code files found ----
   if (nrow(code_files) == 0) {
     info <- list(
+      # code_files here is all_files filtered down to zero rows -- returning
+      # it (rather than omitting `table`) keeps the real base columns
+      # (paper_id, file_location, file_type, ...) in the schema even when
+      # empty. Without this, module_run() set `table` to NULL for this
+      # paper, and a corpus batch with even ONE paper hitting this branch
+      # made bind_rows() across the batch either drop columns entirely (a
+      # zero-column data.frame in the mix) or silently fill them with NA for
+      # every OTHER paper in that batch too -- confirmed on a real 2-paper
+      # batch where neither paper had any code file.
+      table = code_files,
       traffic_light = "na",
       summary_text = summary_code,
       # code_n (not code_file_n): must match the normal-path summary_table's

--- a/inst/modules/codebook_check.R
+++ b/inst/modules/codebook_check.R
@@ -105,10 +105,16 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
   }
 
   empty_summary <- function(text) {
+    # One row per paper still in play (from structure_df, since columns_df is
+    # what's empty here) -- .pid()'s single collapsed id would under-report a
+    # corpus where every paper genuinely has zero tabular data, showing one
+    # row instead of one all-zero row per paper.
+    empty_pids <- if (!is.null(structure_df) && "paper_id" %in% names(structure_df))
+      unique(structure_df$paper_id) else .pid(columns_df, structure_df)
     list(
       table = data.frame(),
       summary_table = data.frame(
-        paper_id = .pid(columns_df, structure_df),
+        paper_id = empty_pids,
         column_n = 0, matched_n = 0, unmatched_n = 0, clean_n = 0,
         conflicted_n = 0, codebook_var_n = 0, unused_var_n = 0
       ),
@@ -173,6 +179,12 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
       cb_group <- if ("group" %in% names(cb_rows)) cb_rows$group[i] else NA_character_
       pv <- parse_codebook(p, group = cb_group)
       if (is.data.frame(pv) && nrow(pv) > 0) {
+        # Attach this file's own paper_id so codebook_vars_df (built below from
+        # parsed_list) can be grouped per paper -- parse_codebook() itself has
+        # no notion of which paper a codebook file belongs to, so this is
+        # stamped on here from cb_rows, the same per-row source cb_group above
+        # already reads from.
+        pv$paper_id <- cb_rows$paper_id[i]
         parsed_list[[length(parsed_list) + 1L]] <- pv
       } else if (is.character(pv) && length(pv) > 0 && llm_use()) {
         # Unstructured text: send to the LLM in 100-line chunks. Upfront gate —
@@ -190,6 +202,7 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
           llm_out <- codebook_parse_llm(pv, basename(p), model, params,
                                         max_chunks = max_llm_chunks)
           if (!is.null(llm_out) && nrow(llm_out) > 0) {
+            llm_out$paper_id <- cb_rows$paper_id[i]
             parsed_list[[length(parsed_list) + 1L]] <- llm_out
             llm_parse_files <- llm_parse_files + 1L
             if (is.na(llm_model_used))
@@ -233,6 +246,7 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
       # "haven" (the codebase's name for an embedded data-file label) gives them
       # that shared authority without touching every haven-keyed call site.
       res$parse_method <- "haven"
+      res$paper_id <- haven_rows$paper_id[i]
       parsed_list[[length(parsed_list) + 1L]] <- res
     }
   }
@@ -516,20 +530,61 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
   n_clean      <- sum(clean)
   n_conflicted <- sum(conflicted)
 
+  # Per-paper versions of the five counts above, for summary_table below (one
+  # row per paper) -- labels_df carries its own paper_id per row (inherited
+  # from columns_df via match_column_labels()), so this is a plain groupby
+  # rather than a corpus-wide scalar repeated on every paper's row.
+  coverage_by_paper <- data.frame(
+    paper_id = labels_df$paper_id, matched = matched, clean = clean,
+    conflicted = conflicted
+  ) |>
+    dplyr::summarise(
+      column_n = dplyr::n(),
+      matched_n = sum(matched),
+      unmatched_n = dplyr::n() - sum(matched),
+      clean_n = sum(clean),
+      conflicted_n = sum(conflicted),
+      .by = paper_id
+    )
+
   # A codebook variable is "used" if any data column matched its name — whether
   # or not the resulting label was clean. This keeps a conflicted-but-present
   # variable out of the "unused" list. Conflicting/ambiguous rows can list
   # several codebook variables (" | "-joined), so split before normalising.
-  matched_norm <- unique(normalize_varname(
-    unlist(strsplit(
-      labels_df$codebook_variable[matched & !is.na(labels_df$codebook_variable)],
-      " | ", fixed = TRUE))
-  ))
+  #
+  # matched_norm/used_var are scoped PER PAPER (via paper_id, present on both
+  # labels_df and codebook_vars_df) rather than computed once across every
+  # paper in a paperlist run: a corpus-wide match set would mark a codebook
+  # variable "used" whenever ANY paper's data happened to share its (very
+  # common, e.g. "age"/"id"/"condition") normalised name, even if that
+  # specific paper's own data never matched it.
+  matched_by_paper <- split(
+    labels_df$codebook_variable[matched & !is.na(labels_df$codebook_variable)],
+    labels_df$paper_id[matched & !is.na(labels_df$codebook_variable)])
+  matched_norm_by_paper <- lapply(matched_by_paper, function(x)
+    unique(normalize_varname(unlist(strsplit(x, " | ", fixed = TRUE)))))
+
   n_codebook_vars <- nrow(codebook_vars_df)
-  used_var <- if (n_codebook_vars > 0)
-    normalize_varname(codebook_vars_df$codebook_variable) %in% matched_norm else
+  used_var <- if (n_codebook_vars > 0) {
+    mn <- matched_norm_by_paper[codebook_vars_df$paper_id]
+    mapply(function(varname, mn_set) varname %in% (mn_set %||% character(0)),
+           normalize_varname(codebook_vars_df$codebook_variable), mn)
+  } else {
     logical(0)
+  }
   n_unused <- sum(!used_var)
+
+  n_codebook_vars_by_paper <- if (n_codebook_vars > 0) {
+    codebook_vars_df |> dplyr::summarise(codebook_var_n = dplyr::n(), .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), codebook_var_n = integer(0))
+  }
+  n_unused_by_paper <- if (n_codebook_vars > 0) {
+    data.frame(paper_id = codebook_vars_df$paper_id, used_var = used_var) |>
+      dplyr::summarise(unused_var_n = sum(!used_var), .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), unused_var_n = integer(0))
+  }
 
   pct_matched <- if (n_columns > 0)
     round(100 * n_matched / n_columns) else 0L
@@ -827,31 +882,33 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
     report <- c(report, paste0("- ", gate_msgs))
 
   # ── 8. Summary table + return ────────────────────────────────────────────────
-  pid <- .pid(labels_df, columns_df, structure_df)
-  summary_table <- data.frame(
-    paper_id       = pid,
-    column_n       = n_columns,
-    matched_n      = n_matched,
-    unmatched_n    = n_unmatched,
-    clean_n        = n_clean,
-    conflicted_n   = n_conflicted,
-    codebook_var_n = n_codebook_vars,
-    unused_var_n   = n_unused,
-    # Scale detection vs. naming: how many data files held a scale-like item
-    # block (rule-based detection), how many distinct instruments were named
-    # (LLM), and how many detected blocks stayed unnamed. The gap between the
-    # first and the last is the "looks like a scale but we can't name it" set.
-    scale_blocks_n  = n_scale_files,
-    scale_named_n   = n_scales_found,
-    scale_unnamed_n = n_scale_unnamed,
-    # Behavioural tasks (Stroop, IAT, n-back). Detected from a different data
-    # signature than scales — rt/accuracy columns rather than a Likert block —
-    # so counted separately. `task_paper_only_n` is the task named in the
-    # manuscript with no matching data: measured but seemingly not shared.
-    task_files_n     = n_task_files,
-    task_named_n     = n_tasks_found,
-    task_paper_only_n = n_tasks_paper_only
-  )
+  # One row per paper (see coverage_by_paper / n_codebook_vars_by_paper /
+  # n_unused_by_paper built earlier), not .pid(...)'s single collapsed id --
+  # that always returns just the FIRST paper's id on a paperlist, the same bug
+  # already fixed for repo_check.R and data_check.R's summary_table.
+  #
+  # scale_blocks_n/scale_named_n/scale_unnamed_n/task_files_n/task_named_n/
+  # task_paper_only_n remain corpus-wide scalars (repeated on every paper's
+  # row below) rather than true per-paper counts: unlike the coverage/codebook
+  # counts above, these come from scale_groups and the scan_paper_for_*()
+  # dictionary scans, which are built once across the whole run and would need
+  # a larger restructuring (making scale_groups itself paper_id-aware) to
+  # split correctly per paper. Tracked as a known remaining gap, not silently
+  # different from this module's behaviour before this fix.
+  summary_table <- data.frame(paper_id = unique(labels_df$paper_id) %||% .pid(labels_df, columns_df, structure_df)) |>
+    dplyr::left_join(coverage_by_paper, by = "paper_id") |>
+    dplyr::left_join(n_codebook_vars_by_paper, by = "paper_id") |>
+    dplyr::left_join(n_unused_by_paper, by = "paper_id")
+  for (col in c("column_n", "matched_n", "unmatched_n", "clean_n", "conflicted_n",
+                "codebook_var_n", "unused_var_n")) {
+    summary_table[[col]][is.na(summary_table[[col]])] <- 0L
+  }
+  summary_table$scale_blocks_n   <- n_scale_files
+  summary_table$scale_named_n    <- n_scales_found
+  summary_table$scale_unnamed_n  <- n_scale_unnamed
+  summary_table$task_files_n     <- n_task_files
+  summary_table$task_named_n     <- n_tasks_found
+  summary_table$task_paper_only_n <- n_tasks_paper_only
 
   list(
     table = labels_df,
@@ -1219,9 +1276,26 @@ codebook_parse_llm <- function(lines, src, model, params, max_chunks = 10L) {
     paste(parts[!is.na(parts) & nzchar(parts)], collapse = " ")
   }
 
-  have_paper <- .is_paper(paper) && !is.null(paper$text) && nrow(paper$text) > 0
-  paper_hay  <- if (have_paper)
-    paste(as.character(paper$text$text), collapse = " \n ") else ""
+  # Computed per-file below (paper_hay_for()), not once here: on a paperlist
+  # run `paper` is never a single scivrs_paper, so a bare .is_paper(paper)
+  # check would always be FALSE (silently skipping paper-text corroboration
+  # for every corpus run -- this matcher runs even with llm_use(FALSE), the
+  # default for a corpus run, so this was silently degrading the DEFAULT
+  # path, not just an opt-in LLM tier). Per-file also avoids pooling every
+  # paper's text together as corroboration evidence for any one file.
+  file_paper_id <- if ("paper_id" %in% names(labels_df))
+    stats::setNames(labels_df$paper_id, labels_df$source_file) else
+    stats::setNames(character(0), character(0))
+  paper_for_file <- function(file) {
+    pid <- unname(file_paper_id[file])
+    if (is.na(pid) || !.is_paper_list(paper)) return(paper)
+    paper[[pid]] %||% paper
+  }
+  paper_hay_for <- function(file) {
+    p <- paper_for_file(file)
+    if (!.is_paper(p) || is.null(p$text) || nrow(p$text) == 0) return("")
+    paste(as.character(p$text$text), collapse = " \n ")
+  }
 
   # Does instrument `i`'s FULL NAME appear in `hay`? Corroboration deliberately
   # requires the full name, NOT the bare acronym: an acronym like "BES" in a
@@ -1275,7 +1349,7 @@ codebook_parse_llm <- function(lines, src, model, params, max_chunks = 10L) {
       cb_hay <- wording_of(file, nms)           # codebook wording FIRST
       # Corroborate each candidate: codebook, then paper.
       cb_ok <- vapply(cand, corroborates, logical(1), hay = cb_hay)
-      pp_ok <- vapply(cand, corroborates, logical(1), hay = paper_hay)
+      pp_ok <- vapply(cand, corroborates, logical(1), hay = paper_hay_for(file))
       corr  <- cb_ok | pp_ok
 
       pick <- NA_integer_; conf <- NA_character_
@@ -1355,14 +1429,33 @@ codebook_parse_llm <- function(lines, src, model, params, max_chunks = 10L) {
   }
   dict$.nkey <- vapply(dict$name, first_tok, character(1))
 
-  have_paper <- .is_paper(paper) && !is.null(paper$text) && nrow(paper$text) > 0
-  paper_hay  <- if (have_paper)
-    paste(as.character(paper$text$text), collapse = " \n ") else ""
+  # Computed per-file below (paper_hay_for()), not once here: on a paperlist
+  # run `paper` is never a single scivrs_paper, so a bare .is_paper(paper)
+  # check would always be FALSE (silently skipping paper-text corroboration
+  # for every corpus run -- this matcher runs even with llm_use(FALSE), the
+  # default for a corpus run). Per-file also avoids pooling every paper's
+  # text together as corroboration evidence for any one file's task columns.
+  file_paper_id <- if ("paper_id" %in% names(labels_df))
+    stats::setNames(labels_df$paper_id, labels_df$source_file) else
+    stats::setNames(character(0), character(0))
+  paper_for_file <- function(file) {
+    pid <- unname(file_paper_id[file])
+    if (is.na(pid) || !.is_paper_list(paper)) return(paper)
+    paper[[pid]] %||% paper
+  }
+  paper_hay_for <- function(file) {
+    p <- paper_for_file(file)
+    if (!.is_paper(p) || is.null(p$text) || nrow(p$text) == 0) return("")
+    paste(as.character(p$text$text), collapse = " \n ")
+  }
 
   # Corroboration requires the FULL NAME in the text, never a bare acronym —
   # the same rule the scale matcher uses, and for the same reason: "IAT" and
-  # "CRT" are ambiguous outside their context.
+  # "CRT" are ambiguous outside their context. Reads `file` from the enclosing
+  # for-loop below rather than taking it as a parameter, since its only
+  # caller (corr <- vapply(cand, corroborates, ...)) is inside that loop.
   corroborates <- function(i) {
+    paper_hay <- paper_hay_for(file)
     if (!nzchar(paper_hay)) return(FALSE)
     pat <- .scale_text_pattern(dict$name[i], NA_character_)
     isTRUE(tryCatch(grepl(pat, paper_hay, perl = TRUE, ignore.case = TRUE),
@@ -2273,6 +2366,19 @@ codebook_parse_llm <- function(lines, src, model, params, max_chunks = 10L) {
   dict <- .scale_dictionary()
   lbl_key <- if (all(c("source_file","column_name") %in% names(labels_df)))
     paste(labels_df$source_file, labels_df$column_name, sep = "\x01") else character(0)
+  # file -> owning paper_id, so .scale_paper_context() below searches only
+  # THAT paper's text -- without this, passing the whole (possibly multi-paper)
+  # `paper` argument through pools every paper's sentences together, so a
+  # scale abbreviation in one paper could get "confirmed" by another paper's
+  # unrelated prose describing a different instrument.
+  file_paper_id <- if ("paper_id" %in% names(labels_df))
+    stats::setNames(labels_df$paper_id, labels_df$source_file) else
+    stats::setNames(character(0), character(0))
+  paper_for_file <- function(file) {
+    pid <- unname(file_paper_id[file])
+    if (is.na(pid) || !.is_paper_list(paper)) return(paper)
+    paper[[pid]] %||% paper
+  }
   wording_of <- function(file, cols) {
     if (!length(lbl_key)) return(character(0))
     i <- match(paste(file, cols, sep = "\x01"), lbl_key)
@@ -2782,7 +2888,24 @@ codebook_parse_llm <- function(lines, src, model, params, max_chunks = 10L) {
            if ("question" %in% names(labels_df)) labels_df$question[i])
     w[!is.na(w) & nzchar(w)]
   }
-  have_paper <- .is_paper(paper) && !is.null(paper$text) && nrow(paper$text) > 0
+  # Per-file, not once: on a paperlist run `paper` is never a single
+  # scivrs_paper object, so a bare .is_paper(paper) check here would always be
+  # FALSE (silently skipping manuscript-text context for every corpus run),
+  # and passing the whole paperlist through to .scale_paper_context() would
+  # pool every paper's sentences together for whichever file is currently
+  # being processed.
+  file_paper_id <- if ("paper_id" %in% names(labels_df))
+    stats::setNames(labels_df$paper_id, labels_df$source_file) else
+    stats::setNames(character(0), character(0))
+  paper_for_file <- function(file) {
+    pid <- unname(file_paper_id[file])
+    if (is.na(pid) || !.is_paper_list(paper)) return(paper)
+    paper[[pid]] %||% paper
+  }
+  have_paper_for <- function(file) {
+    p <- paper_for_file(file)
+    .is_paper(p) && !is.null(p$text) && nrow(p$text) > 0
+  }
 
   type_spec <- ellmer::type_object(
     construct = ellmer::type_string(
@@ -2824,8 +2947,8 @@ codebook_parse_llm <- function(lines, src, model, params, max_chunks = 10L) {
       keys <- paste(file, nms, sep = "\x01")
       if (any(keys %in% named_key)) next          # already named — skip
       wording <- wording_of(file, nms)
-      ctx <- if (have_paper)
-        .scale_paper_context(paper, .scale_name_prefix(nms[[1]]), wording) else
+      ctx <- if (have_paper_for(file))
+        .scale_paper_context(paper_for_file(file), .scale_name_prefix(nms[[1]]), wording) else
         character(0)
       # Descriptive words in the column names themselves (letters-only tokens of
       # >= 3 chars, minus a stray item-index token). A block whose names carry
@@ -2930,8 +3053,14 @@ codebook_identify_scales <- function(previews, labels_df, model, params,
     if (is.na(i)) return(NA_character_)
     labels_df$label[i]
   }
-  have_paper_text <- .is_paper(paper) &&
-    !is.null(paper$text) && nrow(paper$text) > 0
+  # Checked per-file below (paper_for_file(rep_file)), not once here: on a
+  # paperlist run, bare `paper` is never a single scivrs_paper object, so
+  # gating on .is_paper(paper) here would always be FALSE and silently skip
+  # manuscript-text scale identification for every corpus run.
+  have_paper_text_for <- function(file) {
+    p <- paper_for_file(file)
+    .is_paper(p) && !is.null(p$text) && nrow(p$text) > 0
+  }
 
   # Scales the paper names outright. Offering these as candidates lets the model
   # CONFIRM a stated instrument — far more reliable than guessing from item
@@ -2947,10 +3076,12 @@ codebook_identify_scales <- function(previews, labels_df, model, params,
   } else {
     character(0)
   }
-  paper_scales <- if (have_paper_text) {
-    union(llm_named, .scan_paper_for_scales(paper))
-  } else {
-    character(0)
+  # Computed per-file inside the loop below (paper_scales_for()), not once
+  # here: on a paperlist run there is no single `paper` to scan, and each
+  # file's candidate list should come from its OWN paper's text only.
+  paper_scales_for <- function(file) {
+    if (!have_paper_text_for(file)) return(character(0))
+    union(llm_named, .scan_paper_for_scales(paper_for_file(file)))
   }
 
   # Per file: the Likert-eligible columns (flattened across blocks) and their
@@ -3057,8 +3188,9 @@ codebook_identify_scales <- function(previews, labels_df, model, params,
     # variable-name prefix or its distinctive item words. The Methods section
     # usually names the instrument outright ("the 20-item PANAS ..."), which
     # lets the model confirm rather than guess. Only when a paper is available.
-    ctx <- if (have_paper_text)
-      .scale_paper_context(paper, prefixes, labs) else character(0)
+    ctx <- if (have_paper_text_for(rep_file))
+      .scale_paper_context(paper_for_file(rep_file), prefixes, labs) else character(0)
+    paper_scales <- paper_scales_for(rep_file)
     text_in <- listing
     if (length(paper_scales) > 0)
       text_in <- paste0(
@@ -3130,9 +3262,16 @@ codebook_match_llm <- function(labels_df, columns_df, codebook_vars_df,
   norm_col <- normalize_varname(labels_df$column_name)
 
   # Tier: merge conflicting definitions.
+  # Grouped by paper_id + column_name, not column_name alone: two different
+  # papers can share a column name (e.g. "age"), and without paper_id in the
+  # key, idx1 below would pick just the FIRST paper's row across the whole
+  # corpus and apply its resolved label to every other paper's same-named
+  # column too.
   conflict_idx <- which(labels_df$label_status == "conflicting_definition")
   if (length(conflict_idx) > 0) {
-    conflict_cols <- unique(labels_df$column_name[conflict_idx])
+    conflict_keys <- paste(labels_df$paper_id[conflict_idx],
+                           labels_df$column_name[conflict_idx], sep = "\x01")
+    conflict_cols <- unique(conflict_keys)
     type_spec <- ellmer::type_object(
       equivalent = ellmer::type_boolean("Whether all labels describe the same construct"),
       canonical  = ellmer::type_string("Best single label if equivalent, else empty",
@@ -3143,8 +3282,10 @@ codebook_match_llm <- function(labels_df, columns_df, codebook_vars_df,
       "psychology dataset describe the same construct. If they do, return equivalent=true and",
       "the most human-readable single label as canonical; otherwise equivalent=false."
     )
-    for (cn in conflict_cols) {
-      idx1 <- conflict_idx[labels_df$column_name[conflict_idx] == cn][1]
+    for (key in conflict_cols) {
+      match_pos <- conflict_idx[conflict_keys == key]
+      idx1 <- match_pos[1]
+      cn <- labels_df$column_name[idx1]
       labs <- strsplit(labels_df$label[idx1], " | ", fixed = TRUE)[[1]]
       txt <- sprintf("Column: %s\nCandidate labels:\n%s", cn,
                      paste0("- ", labs, collapse = "\n"))
@@ -3159,7 +3300,7 @@ codebook_match_llm <- function(labels_df, columns_df, codebook_vars_df,
       if (!isTRUE(resp$equivalent[1])) next
       canonical <- resp$canonical[1] %||% ""
       if (is.na(canonical) || !nzchar(canonical)) next
-      apply_idx <- conflict_idx[labels_df$column_name[conflict_idx] == cn]
+      apply_idx <- match_pos
       labels_df$label[apply_idx]        <- canonical
       labels_df$label_status[apply_idx] <- "labelled"
       labels_df$label_method[apply_idx] <- "merged_llm"
@@ -3168,13 +3309,26 @@ codebook_match_llm <- function(labels_df, columns_df, codebook_vars_df,
   }
 
   # Tier: fuzzy-match unlabelled columns to unmatched codebook variables.
+  # Run once PER PAPER (the for (pid in ...) loop below), not once across the
+  # whole labels_df/codebook_vars_df: unlab_cols and unmatched_vars would
+  # otherwise span every paper in a paperlist run, and the match-back at
+  # "rows <- which(norm_col == pnc & ...)" keys only on normalised name, so a
+  # column named e.g. "age" in one paper could get fuzzy-matched to a
+  # different paper's "age" codebook variable. The batching/prompt logic
+  # inside is unchanged from before -- only the paper_id scoping is new.
+  paper_ids_here <- unique(labels_df$paper_id)
+  for (pid in paper_ids_here) {
+  labels_paper_idx <- which(labels_df$paper_id == pid)
+  cbk_paper_idx    <- which(codebook_vars_df$paper_id == pid)
+
   documented <- labels_df$label_status %in% c("labelled", "llm")
-  unlabelled_idx <- which(labels_df$label_status == "unlabelled")
+  unlabelled_idx <- labels_paper_idx[labels_df$label_status[labels_paper_idx] == "unlabelled"]
   matched_norm <- unique(normalize_varname(
-    labels_df$codebook_variable[documented & !is.na(labels_df$codebook_variable)]
+    labels_df$codebook_variable[documented & labels_df$paper_id == pid &
+                                !is.na(labels_df$codebook_variable)]
   ))
   unmatched_vars <- codebook_vars_df[
-    !normalize_varname(codebook_vars_df$codebook_variable) %in% matched_norm,
+    cbk_paper_idx[!normalize_varname(codebook_vars_df$codebook_variable[cbk_paper_idx]) %in% matched_norm],
     , drop = FALSE
   ]
 
@@ -3232,7 +3386,7 @@ codebook_match_llm <- function(labels_df, columns_df, codebook_vars_df,
           pnv <- normalize_varname(resp$codebook_variable[k])
           if (!pnc %in% norm_col[unlabelled_idx] || !pnv %in% norm_unmatched) next
           var_row <- which(norm_unmatched == pnv)[1]
-          rows <- which(norm_col == pnc & labels_df$label_status == "unlabelled")
+          rows <- unlabelled_idx[norm_col[unlabelled_idx] == pnc]
           if (length(rows) == 0 || is.na(var_row)) next
           labels_df$label[rows]             <- unmatched_vars$label[var_row]
           labels_df$codebook_variable[rows] <- unmatched_vars$codebook_variable[var_row]
@@ -3244,6 +3398,7 @@ codebook_match_llm <- function(labels_df, columns_df, codebook_vars_df,
       }
     }
   }
+  } # end for (pid in paper_ids_here)
 
   list(labels_df = labels_df, n_matched = n_matched, n_merged = n_merged,
        model = model_used)

--- a/inst/modules/codebook_check.R
+++ b/inst/modules/codebook_check.R
@@ -108,11 +108,27 @@ codebook_check <- function(paper, local_path = NULL, local_only = FALSE,
     # One row per paper still in play (from structure_df, since columns_df is
     # what's empty here) -- .pid()'s single collapsed id would under-report a
     # corpus where every paper genuinely has zero tabular data, showing one
-    # row instead of one all-zero row per paper.
-    empty_pids <- if (!is.null(structure_df) && "paper_id" %in% names(structure_df))
-      unique(structure_df$paper_id) else .pid(columns_df, structure_df)
+    # row instead of one all-zero row per paper. structure_df can itself now
+    # be a real but ZERO-ROW data frame (data_check()'s own empty-result path
+    # returns a properly-typed empty table rather than NULL) -- in that case
+    # unique(structure_df$paper_id) is character(0), not "no paper_id column
+    # at all", so it must fall through to .pid() too, or the mismatched
+    # length(0) vs length-1 scalar columns below error with "arguments imply
+    # differing number of rows".
+    struct_pids <- if (!is.null(structure_df) && "paper_id" %in% names(structure_df))
+      unique(structure_df$paper_id) else character(0)
+    empty_pids <- if (length(struct_pids) > 0) struct_pids else .pid(columns_df, structure_df)
     list(
-      table = data.frame(),
+      # columns_df (zero rows here) rather than a shapeless data.frame():
+      # it already carries the real base columns (paper_id, source_file,
+      # column_name, ...) that the normal path's `table = labels_df` would
+      # also have, even though it lacks labels_df's own added
+      # label/label_status/codebook_variable columns -- keeping SOME of the
+      # real schema means bind_rows() across a corpus/batch does not drop
+      # every column down to nothing the way a bare data.frame() would (the
+      # same class of bug found and fixed in code_check.R's equivalent
+      # empty-result path).
+      table = columns_df %||% data.frame(),
       summary_table = data.frame(
         paper_id = empty_pids,
         column_n = 0, matched_n = 0, unmatched_n = 0, clean_n = 0,

--- a/inst/modules/data_check.R
+++ b/inst/modules/data_check.R
@@ -1275,13 +1275,43 @@ data_check <- function(paper, local_path = NULL, local_only = FALSE,
 
   empty_col_n <- if (n_columns > 0 && "quality" %in% names(columns_df))
     sum(tolower(columns_df$quality %||% "") == "empty", na.rm = TRUE) else 0L
-  summary_table <- data.frame(
-    paper_id = .pid(all_files),
-    data_file_n = n_tabular_all,
-    column_n = n_columns,
-    empty_col_n = empty_col_n
-  ) |>
+
+  # summary_table is one row per paper, but n_tabular_all/n_columns/empty_col_n
+  # above are corpus-wide totals (used elsewhere for the single narrative
+  # report/traffic_light of this module call) -- re-aggregate per paper_id
+  # here so a multi-paper run doesn't tag every paper with the same combined
+  # total, or (worse) collapse to a single row via .pid(all_files), which
+  # always returns just the first paper's id on a paperlist.
+  data_file_n_by_paper <- if (nrow(all_files) > 0) {
+    all_files |>
+      dplyr::mutate(.__is_tab = is_tabular_data & !is_trial_level) |>
+      dplyr::summarise(data_file_n = sum(.__is_tab), .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), data_file_n = integer(0))
+  }
+  column_n_by_paper <- if (n_columns > 0) {
+    columns_df |> dplyr::summarise(column_n = dplyr::n(), .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), column_n = integer(0))
+  }
+  empty_col_n_by_paper <- if (n_columns > 0 && "quality" %in% names(columns_df)) {
+    columns_df |>
+      dplyr::summarise(
+        empty_col_n = sum(tolower(quality %||% "") == "empty", na.rm = TRUE),
+        .by = paper_id
+      )
+  } else {
+    data.frame(paper_id = character(0), empty_col_n = integer(0))
+  }
+
+  summary_table <- data.frame(paper_id = unique(all_files$paper_id) %||% .pid(all_files)) |>
+    dplyr::left_join(data_file_n_by_paper, by = "paper_id") |>
+    dplyr::left_join(column_n_by_paper, by = "paper_id") |>
+    dplyr::left_join(empty_col_n_by_paper, by = "paper_id") |>
     dplyr::left_join(coltype_wide, by = "paper_id")
+  summary_table$data_file_n[is.na(summary_table$data_file_n)] <- 0L
+  summary_table$column_n[is.na(summary_table$column_n)] <- 0L
+  summary_table$empty_col_n[is.na(summary_table$empty_col_n)] <- 0L
 
   summary_text <- c(summary_files, summary_data, summary_studies,
                      summary_ungrouped, summary_nolocal, summary_omitted,
@@ -1735,6 +1765,71 @@ data_check <- function(paper, local_path = NULL, local_only = FALSE,
                                    column_findings_df$column)))
   n_flagged_files_spreadsheet <- length(unique(spreadsheet_findings_df$source_file))
 
+  # Per-paper versions of the four counts above, for dv_summary_table below.
+  # Neither columns_df's per-column findings nor spreadsheet_findings_df carry
+  # paper_id directly (both are keyed by source_file only), so look it up via
+  # columns_df (source_file -> paper_id, one row per column) and structure_df
+  # (file_name -> paper_id, one row per file) respectively -- both already
+  # carry a real per-row paper_id, unlike the single scalar .pid() collapses
+  # a whole paperlist down to.
+  file_to_paper <- if (!is.null(columns_df) && nrow(columns_df) > 0) {
+    stats::setNames(columns_df$paper_id, columns_df$source_file)
+  } else {
+    character(0)
+  }
+  spreadsheet_file_to_paper <- if (!is.null(structure_df) && nrow(structure_df) > 0) {
+    stats::setNames(structure_df$paper_id, structure_df$file_name)
+  } else {
+    character(0)
+  }
+
+  column_n_dv_by_paper <- if (n_columns > 0 && !is.null(columns_df)) {
+    columns_df |> dplyr::summarise(column_n = dplyr::n(), .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), column_n = integer(0))
+  }
+  n_flagged_by_paper <- if (nrow(column_findings_df) > 0) {
+    data.frame(
+      paper_id = unname(file_to_paper[column_findings_df$source_file]),
+      key = paste(column_findings_df$source_file, column_findings_df$column)
+    ) |>
+      dplyr::summarise(flagged_n = length(unique(key)), .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), flagged_n = integer(0))
+  }
+  # spreadsheet_result$n_files counts XLSX/XLS/ODS/FODS files examined (whether
+  # or not any of them triggered a finding); recompute that same per-file count
+  # grouped by paper_id from structure_df directly, rather than from
+  # spreadsheet_findings_df (which only has rows for files that actually raised
+  # a finding, and would undercount clean spreadsheets).
+  n_spreadsheet_files_by_paper <- {
+    xl_rows <- if (!is.null(structure_df) && nrow(structure_df) > 0) {
+      structure_df[
+        tolower(tools::file_ext(structure_df$file_name)) %in% .dv_spreadsheet_exts &
+          !is.na(structure_df$file_location) &
+          nzchar(structure_df$file_location) &
+          file.exists(structure_df$file_location %||% ""),
+        , drop = FALSE]
+    } else {
+      structure_df[0, , drop = FALSE]
+    }
+    if (!is.null(xl_rows) && nrow(xl_rows) > 0) {
+      xl_rows |> dplyr::summarise(spreadsheet_file_n = dplyr::n(), .by = paper_id)
+    } else {
+      data.frame(paper_id = character(0), spreadsheet_file_n = integer(0))
+    }
+  }
+  n_flagged_files_spreadsheet_by_paper <- if (nrow(spreadsheet_findings_df) > 0) {
+    data.frame(
+      paper_id = unname(spreadsheet_file_to_paper[spreadsheet_findings_df$source_file]),
+      source_file = spreadsheet_findings_df$source_file
+    ) |>
+      dplyr::summarise(spreadsheet_flagged_file_n = length(unique(source_file)),
+                       .by = paper_id)
+  } else {
+    data.frame(paper_id = character(0), spreadsheet_flagged_file_n = integer(0))
+  }
+
   # Per-check tally: how many distinct columns each check flagged (a column can
   # be flagged by several checks, so these overlap and need not sum to n_flagged).
   check_counts <- if (nrow(column_findings_df) > 0) {
@@ -1965,13 +2060,22 @@ data_check <- function(paper, local_path = NULL, local_only = FALSE,
   }
 
   # ── 5. Summary table + return ────────────────────────────────────────────────
-  dv_summary_table <- data.frame(
-    paper_id  = .pid(columns_df),
-    column_n  = n_columns,
-    flagged_n = n_flagged,
-    spreadsheet_file_n = n_spreadsheet_files,
-    spreadsheet_flagged_file_n = n_flagged_files_spreadsheet
-  )
+  # One row per paper (see the per-paper *_by_paper frames built above) rather
+  # than one row for the whole run tagged with .pid(columns_df) -- which always
+  # returns just the FIRST paper's id when this module runs on a paperlist, the
+  # same bug already fixed above for the main summary_table.
+  dv_paper_ids <- data.frame(
+    paper_id = unique(c(column_n_dv_by_paper$paper_id,
+                        n_spreadsheet_files_by_paper$paper_id)) %||%
+      .pid(columns_df))
+  dv_summary_table <- dv_paper_ids |>
+    dplyr::left_join(column_n_dv_by_paper, by = "paper_id") |>
+    dplyr::left_join(n_flagged_by_paper, by = "paper_id") |>
+    dplyr::left_join(n_spreadsheet_files_by_paper, by = "paper_id") |>
+    dplyr::left_join(n_flagged_files_spreadsheet_by_paper, by = "paper_id")
+  for (col in c("column_n", "flagged_n", "spreadsheet_file_n", "spreadsheet_flagged_file_n")) {
+    dv_summary_table[[col]][is.na(dv_summary_table[[col]])] <- 0L
+  }
 
   qualtrics_df <- if (length(qualtrics_specs) > 0)
     dplyr::bind_rows(lapply(qualtrics_specs, function(s) data.frame(
@@ -2018,8 +2122,11 @@ data_check <- function(paper, local_path = NULL, local_only = FALSE,
     # blanket "ex1" default rather than actual evidence. psychds_check surfaces
     # this as a warning instead of implying real structure was detected.
     group_no_evidence = group_no_evidence,
-    summary_table = merge(summary_table, dv_summary_table, by = "paper_id",
-                          all = TRUE, sort = FALSE),
+    # column_n already exists in summary_table (same concept, same value,
+    # computed once above) -- drop it from dv_summary_table before merging so
+    # the two tables don't collide into column_n.x/column_n.y.
+    summary_table = merge(summary_table, dv_summary_table[setdiff(names(dv_summary_table), "column_n")],
+                          by = "paper_id", all = TRUE, sort = FALSE),
     na_replace = c(data_file_n = 0, column_n = 0, empty_col_n = 0,
                    flagged_n = 0, spreadsheet_file_n = 0,
                    spreadsheet_flagged_file_n = 0),

--- a/inst/modules/data_check.R
+++ b/inst/modules/data_check.R
@@ -397,6 +397,15 @@ data_check <- function(paper, local_path = NULL, local_only = FALSE,
         skip_types = skip_types)
     }
     return(list(
+      # all_files here is already the real, correctly-typed base frame
+      # (paper_id, file_name, file_location, ...), just zero rows -- return
+      # it for BOTH table and structure (module_run() sets each to NULL
+      # otherwise) so bind_rows() across a corpus/batch does not drop these
+      # columns to nothing for every paper when even one paper's repo_check
+      # found no files at all (the same class of bug found and fixed in
+      # code_check.R's and codebook_check.R's equivalent empty-result paths).
+      table = all_files,
+      structure = all_files,
       traffic_light = "na",
       summary_text = "We found no files to analyse.",
       gated_repos = listing_gated,

--- a/inst/modules/repo_check.R
+++ b/inst/modules/repo_check.R
@@ -1355,7 +1355,8 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
   n_naming_bad <- nrow(naming_bad)
   n_naming_suggest <- length(unique(naming_suggest$file_name))
 
-  # Per-paper count for summary_table, below. check_file_naming() only takes
+  # Per-paper naming-issues table (with paper_id attached) and its "bad"
+  # count for summary_table, below. check_file_naming() only takes
   # file_name/file_path/data_type (no paper_id in, none out), and its padding
   # check (.file_naming_check_padding()) compares files against each other --
   # correct within one paper's own files, meaningless across unrelated papers.
@@ -1363,16 +1364,33 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
   # file subset, rather than trying to join the corpus-wide naming_issues
   # above back onto paper_id by file_name (file names like "data.csv" repeat
   # across unrelated papers, which would misattribute issues).
-  n_naming_bad_by_paper <- if (nrow(all_files) > 0) {
-    all_files |>
-      dplyr::summarise(
-        naming_issues = {
-          pf <- check_file_naming(
-            file_name, file_path = file_path %||% file_name, data_type = data_type)
-          sum(pf$severity == "bad")
-        },
-        .by = paper_id
-      )
+  #
+  # The tagged result (naming_issues_by_paper) is what gets RETURNED as this
+  # module's top-level `naming_issues` field, below -- data_check() reads
+  # that field via get_prev_outputs("repo_check", "naming_issues") for its
+  # own per-file "Naming issue" column, so it needs paper_id to correctly
+  # scope issues to the right paper on a multi-paper (batch/corpus) run, not
+  # just a corpus-wide count.
+  naming_issues_by_paper_list <- if (nrow(all_files) > 0) {
+    split(all_files, all_files$paper_id) |>
+      lapply(function(df) {
+        pf <- check_file_naming(
+          df$file_name, file_path = df$file_path %||% df$file_name,
+          data_type = df$data_type)
+        if (nrow(pf) > 0) pf$paper_id <- df$paper_id[[1]]
+        pf
+      })
+  } else {
+    list()
+  }
+  naming_issues_by_paper <- if (length(naming_issues_by_paper_list) > 0) {
+    dplyr::bind_rows(naming_issues_by_paper_list)
+  } else {
+    naming_issues[0, , drop = FALSE]
+  }
+  n_naming_bad_by_paper <- if (nrow(naming_issues_by_paper) > 0) {
+    naming_issues_by_paper |>
+      dplyr::summarise(naming_issues = sum(severity == "bad"), .by = paper_id)
   } else {
     data.frame(paper_id = character(0), naming_issues = integer(0))
   }
@@ -1531,7 +1549,12 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
     table = all_files,
     summary_table = summary_table,
     gated_repos = gated_repos,
-    naming_issues = naming_issues,
+    # naming_issues_by_paper (paper_id attached), not the un-tagged
+    # naming_issues used only for this call's own narrative report/summary
+    # text above -- data_check() reads this field via
+    # get_prev_outputs("repo_check", "naming_issues") and needs paper_id to
+    # scope issues to the right paper on a multi-paper run.
+    naming_issues = naming_issues_by_paper,
     roster_check = roster_check,
     group_no_evidence = group_no_evidence,
     na_replace = 0,

--- a/inst/modules/repo_check.R
+++ b/inst/modules/repo_check.R
@@ -1289,6 +1289,20 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
   unknown_files <- all_files$file_name[
     !is.na(all_files$data_type) & all_files$data_type == "unknown"]
   n_unknown <- length(unknown_files)
+  # Per-paper count for summary_table, below -- n_unknown above stays a
+  # corpus-wide total for the narrative report/summary_text (one paragraph per
+  # module call, not per paper), but summary_table is one row per paper, so it
+  # needs its own paper_id-grouped count rather than the same total repeated
+  # on every row.
+  n_unknown_by_paper <- if (nrow(all_files) > 0) {
+    all_files |>
+      dplyr::summarise(
+        files_unknown = sum(!is.na(data_type) & data_type == "unknown"),
+        .by = paper_id
+      )
+  } else {
+    data.frame(paper_id = character(0), files_unknown = integer(0))
+  }
   if (n_unknown > 0) {
     report_unknown <- sprintf(
       "#### Unclassified Files\n\nWe could not classify %d file%s by name or extension: %s. Add a recognisable keyword (`data`, `code`, `materials`, `documentation`, `output`) to the file name, or use a common extension, so both humans and machines can tell what kind of file it is.",
@@ -1340,6 +1354,28 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
   naming_suggest <- naming_issues[naming_issues$severity == "suggestion", , drop = FALSE]
   n_naming_bad <- nrow(naming_bad)
   n_naming_suggest <- length(unique(naming_suggest$file_name))
+
+  # Per-paper count for summary_table, below. check_file_naming() only takes
+  # file_name/file_path/data_type (no paper_id in, none out), and its padding
+  # check (.file_naming_check_padding()) compares files against each other --
+  # correct within one paper's own files, meaningless across unrelated papers.
+  # So this re-runs check_file_naming() once per paper on that paper's own
+  # file subset, rather than trying to join the corpus-wide naming_issues
+  # above back onto paper_id by file_name (file names like "data.csv" repeat
+  # across unrelated papers, which would misattribute issues).
+  n_naming_bad_by_paper <- if (nrow(all_files) > 0) {
+    all_files |>
+      dplyr::summarise(
+        naming_issues = {
+          pf <- check_file_naming(
+            file_name, file_path = file_path %||% file_name, data_type = data_type)
+          sum(pf$severity == "bad")
+        },
+        .by = paper_id
+      )
+  } else {
+    data.frame(paper_id = character(0), naming_issues = integer(0))
+  }
 
   if (nrow(naming_issues) > 0) {
     naming_tbl <- naming_issues
@@ -1459,8 +1495,11 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
       dplyr::across(files_n:files_zip, sum),
       .by = c(paper_id)
     )
-  summary_table$files_unknown <- n_unknown
-  summary_table$naming_issues <- n_naming_bad
+  summary_table <- summary_table |>
+    dplyr::left_join(n_unknown_by_paper, by = "paper_id") |>
+    dplyr::left_join(n_naming_bad_by_paper, by = "paper_id")
+  summary_table$files_unknown[is.na(summary_table$files_unknown)] <- 0L
+  summary_table$naming_issues[is.na(summary_table$naming_issues)] <- 0L
   summary_table$roster_mismatch <- !is.null(roster_check) &&
     length(roster_check$roster) > 0 &&
     (length(roster_check$missing) > 0 || length(roster_check$extra) > 0)


### PR DESCRIPTION
## Summary

`repo_check`, `data_check`, and `codebook_check` each computed part of their `summary_table` using a corpus-wide scalar instead of a per-paper value when the module runs once on a whole paperlist — `module_run()`'s normal calling convention for a corpus, and how a real ~1857-paper run of this pipeline is actually driven. Confirmed on that real run:

- **`repo_check`**: `files_unknown` and `naming_issues` in `summary_table` were the same two numbers on every paper's row (a total across every paper, not that paper's own count). The module's returned `naming_issues` field was also untagged by paper (keyed only by `file_name`), so a downstream consumer like `data_check` (via `get_prev_outputs("repo_check", "naming_issues")`) could not tell which paper a naming issue belonged to on a multi-paper run.
- **`data_check`**: `summary_table` (and its spreadsheet-validation half, `dv_summary_table`) collapsed to a single row tagged with only the first paper's id, so every other paper's `data_file_n`/`column_n`/`empty_col_n` showed 0 or NA regardless of what that paper's repository actually contained.
- **`codebook_check`**: the same collapse-to-one-id pattern in its `summary_table`, plus a more serious bug in `match_column_labels()` and its two LLM-driven matching tiers — matching was keyed on normalised column name only, with no `paper_id` constraint, so a column named e.g. `"age"` in one paper could match a different paper's codebook variable of the same name. Also fixed two rules-based scale/task detectors (`.identify_scales_rules`, `.identify_tasks_rules`) that silently skipped manuscript-text corroboration on every paperlist run, including the default `llm_use(FALSE)` path, since their own paper-detection guard was never true for a paperlist.
- **`code_check`/`codebook_check`/`data_check`**: each has an early-return path for "nothing found" that returned either no `table` field at all or a bare, schema-less `data.frame()`. Confirmed on a real 2-paper batch where neither paper had any code file: `code_check`'s table came back with **zero columns** instead of the normal `paper_id`/`file_location`/`language`/... schema. On a corpus or batch run, even one paper hitting this path could silently drop columns (or fill them with NA) for every other paper once combined with `bind_rows()`.

## Fix

All affected modules now compute per-paper counts via proper `paper_id` grouping/joins instead of ungrouped scalars, matching the pattern already used correctly in `code_check.R` and `stat_p_exact.R`. `codebook_vars_df` gained a `paper_id` column (stamped at the point each codebook/README/haven file is parsed) so its own per-paper aggregation and the paper-scoped match in `match_column_labels()` have something to key on; `match_column_labels()` falls back to its original unscoped behaviour when `codebook_vars_df` has no `paper_id` column at all, for callers that construct it directly (as three existing unit tests do). Each empty-result path now returns its already-available, correctly-typed but zero-row base frame instead of `NULL`/a bare `data.frame()`.

## Test plan

- [x] `test-module-repo_check.R` — all pass, including the existing 2-paper `paperlist()` regression test
- [x] `test-module-codebook_check.R` — all pass
- [x] `test-codebook-helpers.R` — all pass
- [x] Live multi-paper verification: `repo_check → data_check → code_check` chained on real BES corpus papers, confirming per-paper `naming_issues`/`data_file_n`/`column_n` values are correct and distinct (not one repeated constant, not collapsed to a single row)
- [x] Live verification that a batch with zero code files across every paper still returns a properly-shaped `table` (13 real columns) instead of a zero-column frame