### PR TITLE
Support Figshare project URLs; surface unresolvable private share links

### DIFF
--- a/R/archive-figshare.R
+++ b/R/archive-figshare.R
@@ -51,7 +51,7 @@ figshare_links <- function(paper) {
     dplyr::filter(grepl("figshare\\.com|10\\.6084/m9\\.figshare", href, ignore.case = TRUE))
 
   fs_bare_regex <- paste0(
-    "(?:https?://)?(?:[a-z0-9.-]+\\.)?figshare\\.com/(?:articles|ndownloader)/[A-Za-z0-9/_.-]*",
+    "(?:https?://)?(?:[a-z0-9.-]+\\.)?figshare\\.com/(?:articles|ndownloader|projects|s)/[A-Za-z0-9/_.-]*",
     "|(?:https?://)?(?:doi\\.org/)?10\\.6084/m9\\.figshare\\.[0-9]+(?:\\.v[0-9]+)?"
   )
   other_fs <- text_search(paper, fs_bare_regex, return = "match", perl = TRUE) |>
@@ -67,6 +67,21 @@ figshare_links <- function(paper) {
 
   links$figshare_url <- links$href
   links$figshare_id <- .figshare_id(links$figshare_url)
+
+  # A private "share link" (figshare.com/s/<hash>) carries no article id
+  # anywhere in the URL -- the hash IS the whole identifier, resolved only by
+  # Figshare's own front end after an AWS WAF bot challenge (verified live
+  # 2026-08-30: a plain HTTP request gets an explicit "we need to verify
+  # you're not a robot... this requires JavaScript" challenge page, not real
+  # content). There is no documented, plain-HTTP API endpoint that accepts
+  # this token (the /v2/account/articles/{id}/private_links/{token} family
+  # is for the OWNER managing their own links, not a third party resolving
+  # someone else's). Flagged rather than silently dropped, so a paper citing
+  # one is visibly reported as "found a Figshare link, could not resolve it"
+  # instead of looking like no Figshare link existed at all.
+  links$figshare_unsupported <- grepl("figshare\\.com/s/[A-Za-z0-9]+",
+                                      links$figshare_url, ignore.case = TRUE) &
+    is.na(links$figshare_id)
 
   return(links)
 }
@@ -120,6 +135,77 @@ figshare_links <- function(paper) {
   return(NA_character_)
 }
 
+# Get a Figshare PROJECT id from a URL, e.g.
+# "figshare.com/projects/PERICLES_-_Heritage_values/133332" -> "133332".
+# Kept entirely separate from .figshare_id() (rather than adding a project
+# pattern to that function's own list) because a project id and an article
+# id are different resource types on different API paths -- an article id
+# from .figshare_id() is used directly as .../v2/articles/{id}, while a
+# project id needs .../v2/projects/{id}/articles first to find the article
+# ids it actually contains (see .figshare_project_articles()). Conflating
+# the two would silently 404 (or worse, alias onto an unrelated article that
+# happens to share the same numeric id) rather than erroring clearly.
+.figshare_project_id <- function(figshare_url) {
+  if (length(figshare_url) == 0) return(character(0))
+  if (length(figshare_url) > 1) return(vapply(figshare_url, .figshare_project_id, character(1)))
+
+  figshare_url <- trimws(as.character(figshare_url))
+  if (is.na(figshare_url) || !nzchar(figshare_url)) return(NA_character_)
+
+  # The project's numeric id is always the LAST path segment -- confirmed
+  # live against https://figshare.com/projects/PERICLES_-_Heritage_values/133332,
+  # whose project name segment itself can contain further slashes' worth of
+  # punctuation-adjacent characters, so anchoring on "the segment right
+  # after /projects/" would be wrong; anchoring on "the trailing digits"
+  # is not.
+  match <- regexec("figshare\\.com/projects/[^/]+/([0-9]+)/?$", figshare_url,
+                   perl = TRUE, ignore.case = TRUE)
+  groups <- regmatches(figshare_url, match)[[1]]
+  if (length(groups) >= 2) return(groups[[2]])
+  NA_character_
+}
+
+# List the article ids a Figshare PROJECT contains, via the public
+# GET /v2/projects/{id}/articles endpoint (verified live 2026-08-30, and
+# documented as a "Public endpoints" entry not requiring authentication --
+# https://docs.figshare.com/old_docs/api/projects/ -- unlike the
+# /v2/account/projects/ family, which is for a signed-in user's OWN
+# projects). Paginated at page_size=100; a project bundling more than that
+# many articles is realistically rare for a single paper's supplementary
+# data, but the loop still follows pagination properly rather than assuming
+# one page is always enough.
+.figshare_project_articles <- function(project_id, host = "api.figshare.com", pb = NULL) {
+  if (is.null(pb)) {
+    pb <- pb(NA, "(:spin) :what")
+    on.exit(pb$terminate())
+  }
+
+  all_ids <- character(0)
+  page <- 1L
+  repeat {
+    api_url <- sprintf("https://%s/v2/projects/%s/articles?page=%d&page_size=100",
+                       host, project_id, page)
+    resp <- .batch_query(api_url, msg = NULL,
+                         req_func = \(req) .figshare_headers(req, host = host))[[1]]
+    if (is.null(resp) || httr2::resp_status(resp) != 200) {
+      if (length(all_ids) == 0) {
+        warning("Figshare project ", project_id, " could not be found on ", host,
+                call. = FALSE)
+      }
+      break
+    }
+    rec <- tryCatch(httr2::resp_body_json(resp), error = \(e) NULL)
+    if (is.null(rec) || length(rec) == 0) break
+
+    ids <- vapply(rec, function(a) as.character(a$id %||% NA_character_), character(1))
+    all_ids <- c(all_ids, ids[!is.na(ids)])
+
+    if (length(rec) < 100) break   # last page
+    page <- page + 1L
+  }
+  unique(all_ids)
+}
+
 #' Retrieve info from Figshare by URL
 #'
 #' @param figshare_url a Figshare URL or DOI, or a table containing them
@@ -162,6 +248,42 @@ figshare_info <- function(figshare_url, id_col = 1, host = "api.figshare.com", p
   ) |>
     unique()
   ids <- ids[!is.na(ids$figshare_url), , drop = FALSE]
+
+  # A PROJECT url (figshare.com/projects/<name>/<id>) has no article id of
+  # its own -- .figshare_id() correctly returns NA for it, since a project
+  # bundles multiple articles rather than being one. Expand each such url
+  # into one row per article the project actually contains (one project url
+  # -> N article-id rows, the same shape as if the paper had cited N
+  # separate article urls directly), via the public projects/{id}/articles
+  # endpoint. A project with zero articles, or one .figshare_project_id()
+  # fails to resolve at all, simply contributes no rows here and its url
+  # stays NA in `ids` -- reported the same way any other unresolvable
+  # Figshare link already is, not a special case.
+  unresolved <- is.na(ids$figshare_id)
+  if (any(unresolved)) {
+    project_urls <- ids$figshare_url[unresolved]
+    project_ids <- .figshare_project_id(project_urls)
+    has_project <- !is.na(project_ids)
+    if (any(has_project)) {
+      project_rows <- Map(function(url, proj_id) {
+        article_ids <- .figshare_project_articles(proj_id, host = host, pb = pb)
+        if (length(article_ids) == 0) return(NULL)
+        data.frame(figshare_url = url, figshare_id = article_ids, stringsAsFactors = FALSE)
+      }, project_urls[has_project], project_ids[has_project])
+      project_rows <- project_rows[!vapply(project_rows, is.null, logical(1))]
+      if (length(project_rows) > 0) {
+        # Drop the original NA-id placeholder rows for urls that just
+        # successfully expanded into real article rows, so a project ends
+        # up as N article rows, not N+1 (the extra one carrying no id, no
+        # title, no doi -- confirmed live: without this, figshare_info() on
+        # a project url returned 9 rows for an 8-article project).
+        expanded_urls <- unique(vapply(project_rows, function(r) r$figshare_url[[1]], character(1)))
+        ids <- ids[!(ids$figshare_url %in% expanded_urls & is.na(ids$figshare_id)), , drop = FALSE]
+        ids <- dplyr::bind_rows(ids, do.call(rbind, project_rows)) |> unique()
+      }
+    }
+  }
+
   valid_ids <- unique(stats::na.omit(ids$figshare_id))
 
   if (length(valid_ids) == 0) {

--- a/inst/modules/repo_check.R
+++ b/inst/modules/repo_check.R
@@ -122,6 +122,21 @@ repo_check <- function(paper, local_path = NULL, local_only = FALSE,
   names(repos)[2] <- "repo_url"
   repos$repo_error <- NA_character_
 
+  # A Figshare private "share link" (figshare.com/s/<hash>) is a real,
+  # detected Figshare mention that cannot be resolved any further -- the
+  # hash is opaque and Figshare's own resolution page is behind an AWS WAF
+  # bot challenge, with no documented plain-HTTP API alternative (see
+  # figshare_links()'s own comment). Flagged via repo_error (the same field
+  # every other unreachable-repo case in this module uses, e.g. a private
+  # OSF project) rather than left silently indistinguishable from "no
+  # Figshare link found at all" or from a merely malformed/broken url.
+  if ("figshare_unsupported" %in% names(figshare_links_found) &&
+      any(figshare_links_found$figshare_unsupported %in% TRUE)) {
+    unsupported_urls <- figshare_links_found$href[figshare_links_found$figshare_unsupported %in% TRUE]
+    repos$repo_error[repos$repo_url %in% unsupported_urls] <-
+      "private share link (figshare.com/s/...) cannot be resolved without a browser"
+  }
+
   # get files ----
 
   ## OSF ----

--- a/tests/testthat/test-archive-figshare.R
+++ b/tests/testthat/test-archive-figshare.R
@@ -1,0 +1,122 @@
+test_that("figshare_links finds article, project, and share-link urls", {
+  expect_true(is.function(metacheck::figshare_links))
+  expect_no_error(helplist <- help(figshare_links, metacheck))
+
+  paper <- test_paper(url = c(
+    "https://figshare.com/articles/dataset/some_title/18093368",
+    "https://figshare.com/projects/PERICLES_-_Heritage_values/133332",
+    "https://figshare.com/s/5e01cc0cae4cf3e2e14f",
+    "https://osf.io/abcde"
+  ))
+
+  links <- figshare_links(paper)
+
+  expect_equal(nrow(links), 3)
+  expect_true(all(c(
+    "https://figshare.com/articles/dataset/some_title/18093368",
+    "https://figshare.com/projects/PERICLES_-_Heritage_values/133332",
+    "https://figshare.com/s/5e01cc0cae4cf3e2e14f"
+  ) %in% links$href))
+
+  # article url resolves to a real id; project and share-link urls do not
+  # (a project bundles multiple articles rather than being one, and a
+  # share-link's hash is opaque -- see .figshare_id()'s own comment)
+  by_url <- setNames(links$figshare_id, links$href)
+  expect_equal(unname(by_url["https://figshare.com/articles/dataset/some_title/18093368"]),
+              "18093368")
+  expect_true(is.na(by_url["https://figshare.com/projects/PERICLES_-_Heritage_values/133332"]))
+  expect_true(is.na(by_url["https://figshare.com/s/5e01cc0cae4cf3e2e14f"]))
+
+  # only the share-link is flagged unsupported -- a project url is NOT
+  # unsupported (it is fully resolvable, just via a different mechanism;
+  # see figshare_info()'s project-expansion)
+  by_flag <- setNames(links$figshare_unsupported, links$href)
+  expect_false(by_flag[["https://figshare.com/articles/dataset/some_title/18093368"]])
+  expect_false(by_flag[["https://figshare.com/projects/PERICLES_-_Heritage_values/133332"]])
+  expect_true(by_flag[["https://figshare.com/s/5e01cc0cae4cf3e2e14f"]])
+})
+
+
+test_that(".figshare_id", {
+  expect_true(is.function(metacheck:::.figshare_id))
+
+  figshare_url <- c(
+    "18093368",
+    "https://figshare.com/articles/dataset/some_title/18093368",
+    "https://figshare.com/articles/18093368",
+    "https://doi.org/10.6084/m9.figshare.18093368",
+    "10.6084/m9.figshare.18093368.v1",
+    "https://ndownloader.figshare.com/files/12345",
+    "https://figshare.com/projects/some_project/133332",  # project, not an article
+    "https://figshare.com/s/5e01cc0cae4cf3e2e14f",         # share link, opaque hash
+    "not-a-figshare-url",
+    ""
+  )
+
+  ids <- .figshare_id(figshare_url)
+  expect_equal(unname(ids), c(
+    "18093368", "18093368", "18093368", "18093368", "18093368",
+    "12345", NA, NA, NA, NA
+  ))
+
+  # NULL / empty
+  expect_equal(.figshare_id(NULL), character(0))
+})
+
+
+test_that(".figshare_project_id", {
+  expect_true(is.function(metacheck:::.figshare_project_id))
+
+  project_url <- c(
+    "https://figshare.com/projects/PERICLES_-_Heritage_values/133332",
+    "https://figshare.com/projects/A_Project_With-Punctuation.In.It/999",
+    "https://figshare.com/articles/dataset/some_title/18093368",  # article, not a project
+    "not-a-figshare-url",
+    ""
+  )
+
+  ids <- .figshare_project_id(project_url)
+  expect_equal(unname(ids), c("133332", "999", NA, NA, NA))
+})
+
+
+test_that(".figshare_project_articles lists a real project's articles", {
+  expect_true(is.function(metacheck:::.figshare_project_articles))
+
+  # PERICLES Heritage values project, verified live 2026-08-30 to hold 8
+  # articles via GET https://api.figshare.com/v2/projects/133332/articles
+  article_ids <- .figshare_project_articles("133332")
+
+  expect_true(length(article_ids) >= 1)
+  expect_true(all(grepl("^[0-9]+$", article_ids)))
+  expect_true(!anyDuplicated(article_ids))
+})
+
+
+test_that("figshare_info expands a project url into one row per article", {
+  expect_true(is.function(metacheck::figshare_info))
+  expect_no_error(helplist <- help(figshare_info, metacheck))
+
+  info <- figshare_info("https://figshare.com/projects/PERICLES_-_Heritage_values/133332")
+
+  # every row shares the same source url (traceable back to what the paper
+  # actually cited) but has its own resolved article id/title/doi
+  expect_true(nrow(info) >= 1)
+  expect_true(all(info$figshare_url ==
+                 "https://figshare.com/projects/PERICLES_-_Heritage_values/133332"))
+  expect_false(anyNA(info$figshare_id))
+  expect_false(anyNA(info$doi))
+  expect_true(!anyDuplicated(info$figshare_id))
+})
+
+
+test_that("figshare_info on a single article still returns exactly one row", {
+  # Guards against the project-expansion logic accidentally affecting the
+  # plain single-article path (confirmed live before this test existed: an
+  # early version of the expansion left a stray NA-id row alongside the
+  # real ones for a PROJECT url -- this test covers the non-project path
+  # staying unaffected).
+  info <- figshare_info("https://doi.org/10.6084/m9.figshare.18093368")
+  expect_equal(nrow(info), 1)
+  expect_false(is.na(info$figshare_id))
+})


### PR DESCRIPTION
## Summary

Found while checking metacheck's output against Cooper et al.'s corpus: an interim comparison run on the first 250 papers found 6 where Cooper coded a real Figshare-hosted dataset but metacheck detected no repository at all. Traced to two unsupported Figshare URL shapes — neither a general Figshare failure, since plain article/DOI links already worked correctly.

### 1. Project URLs (`figshare.com/projects/<name>/<id>`)

A project bundles multiple articles rather than being one, so it has no article id of its own — `.figshare_id()` correctly returned `NA` for it, but nothing then tried to resolve it as a project. Added `.figshare_project_id()` (extracts the trailing numeric id) and `.figshare_project_articles()` (lists the project's article ids via the public, unauthenticated `GET /v2/projects/{id}/articles` endpoint), wired into `figshare_info()` so a project url expands into **one row per article** — the same shape as if the paper had cited each article url directly.

Verified live against a real project (PERICLES Heritage values, 8 articles): `repo_check()` on the affected paper now finds 94 files, up from 0.

Also extended `figshare_links()`'s bare-text regex to match `/projects/` urls at all (it previously only matched `articles`/`ndownloader`), since both real project-url misses in the sample were bare-text mentions rather than real hyperlinks.

### 2. Private share links (`figshare.com/s/<hash>`)

The hash is an opaque token with no article id anywhere in the URL, and Figshare's own resolution page sits behind an AWS WAF bot challenge — confirmed live: a plain request gets an explicit *"we need to verify you're not a robot... this requires JavaScript"* challenge page, on every URL variant tried (the bare share link, one with a `file=` query parameter, and the direct `ndownloader` endpoint with a `private_link=` parameter — all three revealed by following a real browser's redirect chain). No documented plain-HTTP API alternative exists for a third party to resolve someone else's share link (the `/v2/account/articles/{id}/private_links/` family is for the *owner* managing their own links). Passing the challenge programmatically would require emulating a real browser session, which is out of scope as bot-detection evasion.

Rather than staying invisible (previously indistinguishable from "no Figshare link found"), `figshare_links()` now flags these via a new `figshare_unsupported` column, and `repo_check()` surfaces them through `repo_error` (*"private share link cannot be resolved without a browser"*) — the same mechanism already used for a private OSF project or a gated repository, so the link is visible in `gated_repos` for a human to follow up on manually.

## Test plan
- [x] New `tests/testthat/test-archive-figshare.R` (28 assertions) — Figshare previously had no dedicated test file at all
- [x] Full package test suite unaffected (`FAIL 0 | WARN 0 | SKIP 67 | PASS 4297`, up from 4269 passes on the same clean baseline — the 28 new assertions)
- [x] Live verification against the real papers and real Figshare API (project expansion, share-link flagging)