### PR TITLE
Fix code_check crash when every file in a batch fails to download

### DIFF
--- a/inst/modules/code_check.R
+++ b/inst/modules/code_check.R
@@ -384,7 +384,15 @@ code_check <- function(paper, local_path = NULL,
   # Reporting ----
 
   ## library ----
-  library_sep <- sapply(code_files$library_max_between > 3, isTRUE)
+  # vapply(), not sapply(): sapply() on a zero-length input (every checked
+  # file errored before ever setting library_max_between -- e.g. every
+  # download in the batch failed, confirmed live 2026-08-31 against a real
+  # corpus run hitting a genuinely exhausted Dryad rate limit) silently
+  # returns list() instead of logical(0), and code_files$file_name[list()]
+  # then throws "invalid subscript type 'list'" -- a real crash that took
+  # down an entire batch of an unattended corpus run. vapply()'s explicit
+  # FUN.VALUE always returns the declared type, empty input included.
+  library_sep <- vapply(code_files$library_max_between > 3, isTRUE, logical(1))
   library_issue <- code_files$file_name[library_sep]
   if (length(library_issue) == 0) {
     report_library <- "Best programming practice is to load all required libraries/imports in one block near the top of the code. In all code files, libraries/imports were loaded in one block."
@@ -459,10 +467,24 @@ code_check <- function(paper, local_path = NULL,
       plural(length(comment_issue))
     )
   }
-  cols <- c("file_name", "language", "percentage_comment")
-  rows <- !is.na(code_files$percentage_comment)
-  report_table_comments <- code_files[rows, cols]
-  report_table_comments$percentage_comment <- sprintf("%.0f%%", report_table_comments$percentage_comment * 100)
+  # "percentage_comment" is only set inside the per-file try block above, on
+  # a file that was actually read -- absent from code_files entirely (not
+  # just NA) when every checked file errored before reaching that point,
+  # e.g. every download in the batch failed (confirmed live 2026-08-31:
+  # code_files[rows, cols] below throws "undefined columns selected" in
+  # exactly that scenario, a real crash that took down an entire batch of an
+  # unattended corpus run). n_analysed/comment_issue above already handle
+  # this correctly (NULL column -> is.na()/== both give an empty, not an
+  # error), so mirror that here: an absent column means nothing to report.
+  if ("percentage_comment" %in% names(code_files)) {
+    cols <- c("file_name", "language", "percentage_comment")
+    rows <- !is.na(code_files$percentage_comment)
+    report_table_comments <- code_files[rows, cols]
+    report_table_comments$percentage_comment <- sprintf("%.0f%%", report_table_comments$percentage_comment * 100)
+  } else {
+    report_table_comments <- code_files[0, c("file_name", "language"), drop = FALSE]
+    report_table_comments$percentage_comment <- character(0)
+  }
   colnames(report_table_comments) <- c(
     "File name", "Language", "Percent comments"
   )
@@ -677,19 +699,32 @@ code_check <- function(paper, local_path = NULL,
   }
 
   # Aggregate by paper
+  # Every code_* column below except code_n/code_checked is only set inside
+  # the per-file try block earlier in this function, on a file that was
+  # actually read -- absent from code_files entirely (not just NA-filled)
+  # when every checked file errored before reaching that point, e.g. every
+  # download in the batch failed (confirmed live 2026-08-31: unguarded
+  # references here threw "In argument: `code_abs_path = sum(code_abs_path,
+  # na.rm = TRUE)`", a real crash that took down an entire batch of an
+  # unattended corpus run -- code_setwd was already guarded this way; the
+  # rest were not, which was the actual bug).
+  has_col <- function(col) col %in% names(code_files)
   summary_table <- code_files |>
     dplyr::summarise(
       code_n = dplyr::n(),
       code_checked = sum(checked, na.rm = TRUE),
-      code_abs_path = sum(code_abs_path, na.rm = TRUE),
-      code_setwd = if ("code_setwd" %in% names(code_files))
+      code_abs_path = if (has_col("code_abs_path"))
+        sum(code_abs_path, na.rm = TRUE) else 0L,
+      code_setwd = if (has_col("code_setwd"))
         sum(code_setwd, na.rm = TRUE) else 0L,
-      code_missing_files = sum(loaded_files_missing, na.rm = TRUE),
+      code_missing_files = if (has_col("loaded_files_missing"))
+        sum(loaded_files_missing, na.rm = TRUE) else 0L,
       # Guard the all-NA group (e.g. a file with no parseable code lines):
       # min(na.rm = TRUE) would warn and return Inf, so fall back to NA.
-      code_min_comments = if (any(!is.na(percentage_comment)))
+      code_min_comments = if (has_col("percentage_comment") && any(!is.na(percentage_comment)))
         min(percentage_comment, na.rm = TRUE) else NA_real_,
-      code_parse_errors = sum(parse_error, na.rm = TRUE),
+      code_parse_errors = if (has_col("parse_error"))
+        sum(parse_error, na.rm = TRUE) else 0L,
       .by = paper_id
     )
   # Distinct packages per paper (union over that paper's files). Done as a

--- a/tests/testthat/test-module-code_check.R
+++ b/tests/testthat/test-module-code_check.R
@@ -537,3 +537,94 @@ test_that("parse errors", {
 })
 
 
+test_that("code files found but every download fails does not crash (invalid subscript type 'list')", {
+  # Confirmed live 2026-08-31: a real 1861-paper corpus run crashed here when
+  # a batch's Dryad downloads hit a genuinely exhausted rate limit and EVERY
+  # file in a paper's code_check() call failed to download. This is a
+  # different scenario from "no code files" above (code_n == 0, nothing
+  # matched a checked language) -- here, real code files ARE found (code_n >
+  # 0), but every one of them errors out in the per-file try block before
+  # ever setting its analysis columns (percentage_comment, code_abs_path,
+  # etc.), leaving code_files with real rows but those columns absent
+  # entirely (not just NA). Two separate, real bugs were found and fixed for
+  # this: (1) library_sep <- sapply(...) on that resulting zero-length
+  # column silently returned list() instead of logical(0), and
+  # code_files$file_name[list()] threw "invalid subscript type 'list'";
+  # (2) several column references in the final dplyr::summarise() (0
+  # code_abs_path, 0 loaded_files_missing, 0 percentage_comment) were
+  # unguarded against the column being absent (code_setwd already was,
+  # which is what made the asymmetry visible) and threw "undefined columns
+  # selected" once (1) was fixed.
+  paper <- test_paper(url = "https://doi.org/10.5061/dryad.does-not-matter")
+
+  # A synthetic repo_check() result, fed to code_check() via module_run()'s
+  # normal chaining mechanism (get_prev_outputs("repo_check", "table"),
+  # exactly like build_master_comparison.R's own
+  # module_run(res_repo_check, "data_check") pattern) -- avoids needing to
+  # mock repo_check() itself, which module_run() dispatches via source() +
+  # eval() rather than an ordinary exported binding testthat can intercept.
+  fake_repo_check <- structure(
+    list(
+      module = "repo_check",
+      paper = paper,
+      # module_run() seeds its OWN outer summary_table from the previous
+      # module's summary_table (prev$summary_table %||%
+      # data.frame(paper_id = character(0))), then left_join()s code_check()'s
+      # result onto it -- an empty seed here silently produces a 0-row result
+      # regardless of what code_check() itself computes, so this needs a real
+      # one-row-per-paper summary_table, same as a genuine repo_check() call
+      # would have returned.
+      summary_table = data.frame(paper_id = paper_id(paper)),
+      table = data.frame(
+        paper_id = paper_id(paper),
+        file_name = c("analysis.R", "helpers.R"),
+        repo_url = "https://doi.org/10.5061/dryad.does-not-matter",
+        # file:// to a path that does not exist -- code_read()'s fallback
+        # (file_path <- file_url when file_location is NA, since the mock
+        # below never sets it) then fails LOCALLY and fast, same failure
+        # shape as a real unreachable URL would produce, without this test
+        # making a real network request to a fake host.
+        file_url = c("file:///does/not/exist/analysis.R",
+                     "file:///does/not/exist/helpers.R"),
+        file_location = NA_character_,
+        stringsAsFactors = FALSE
+      )
+    ),
+    class = "metacheck_module_output"
+  )
+
+  mo <- with_mocked_bindings(
+    module_run(fake_repo_check, "code_check"),
+    download_repo_files = function(files, ...) {
+      # Every file "found" but none downloaded -- the exact real-world shape
+      # (file_location stays NA throughout) a confirmed-exhausted rate limit
+      # produces.
+      files$file_location <- NA_character_
+      attr(files, "failed") <- data.frame(
+        repo_url = files$repo_url, file_name = files$file_name,
+        error = "API rate limit exhausted: HTTP 429 Too Many Requests.",
+        stringsAsFactors = FALSE)
+      files
+    },
+    .package = "metacheck"
+  )
+
+  expect_equal(mo$traffic_light, "na")
+  expect_equal(nrow(mo$summary_table), 1)
+  expect_equal(mo$summary_table$code_n, 2)
+  # "checked" means "code_check() attempted to read it" (set unconditionally
+  # at the top of the per-file loop, before the read itself is tried), not
+  # "successfully read" -- both files here were attempted, just failed to
+  # download/read, so this is 2, not 0.
+  expect_equal(mo$summary_table$code_checked, 2)
+  # Every one of these was the crash site (or would have been, unguarded):
+  # confirm they resolve to a safe default rather than erroring, for a
+  # paper where nothing could actually be read.
+  expect_equal(mo$summary_table$code_abs_path, 0L)
+  expect_equal(mo$summary_table$code_setwd, 0L)
+  expect_equal(mo$summary_table$code_missing_files, 0L)
+  expect_true(is.na(mo$summary_table$code_min_comments))
+  expect_equal(mo$summary_table$code_parse_errors, 0L)
+})
+
+


### PR DESCRIPTION
## Summary

Fixes a real crash that stopped an unattended 1861-paper corpus run at batch 27: `code_check()` threw `"invalid subscript type 'list'"` whenever every code file for a paper failed to download (in this case, a genuinely exhausted Dryad rate limit).

Root cause: three places in `code_check.R` assumed at least one file had been successfully read and reached the per-file `try` block. When every file errors out before that point, several columns (`library_max_between`, `percentage_comment`, `code_abs_path`, `loaded_files_missing`, `parse_error`) are absent from `code_files` entirely rather than NA-filled:

1. `sapply(code_files$library_max_between > 3, isTRUE)` on a zero-length input silently returns `list()` instead of `logical(0)`. Subscripting `code_files$file_name` with that `list()` throws `"invalid subscript type 'list'"` — this is the actual crash. Fixed with `vapply()`, whose declared `FUN.VALUE` always returns the right type regardless of input length.
2. The comments-table block assumed `percentage_comment` always exists as a column and threw `"undefined columns selected"` when it didn't. Guarded the same way `n_analysed`/`comment_issue` already handled it.
3. The final `summary_table` `dplyr::summarise()` referenced `code_abs_path`, `loaded_files_missing`, `percentage_comment`, and `parse_error` unguarded. `code_setwd` already had an `if (col %in% names(code_files))` guard for the same reason; the other four did not. Added the same guard via a small `has_col()` helper.

Found by investigating the corpus-run crash: mocking `download_repo_files()` to always fail reproduced it deterministically, which allowed bisecting the crash to the exact `sapply()` line.

## Test plan

- [x] New regression test in `test-module-code_check.R` reproducing the exact scenario (every file's download fails) via a mocked `download_repo_files()`.
- [x] Full package test suite passes clean: `FAIL 0 | WARN 0 | SKIP 68 | PASS 4323`.